### PR TITLE
Fix runtime package searching

### DIFF
--- a/lowarn/package.yaml
+++ b/lowarn/package.yaml
@@ -24,6 +24,7 @@ dependencies:
 - ghc == 9.0.2
 - ghc-paths
 - unix
+- transformers
 
 ghc-options:
 - -Wall


### PR DESCRIPTION
Starts a new GHC session for every program load, which ensures that the package database is also reloaded. Fixes #19.