### PR TITLE
Use only one GHC session per runtime

### DIFF
--- a/core/src/Lowarn/DynamicLinker.hs
+++ b/core/src/Lowarn/DynamicLinker.hs
@@ -104,9 +104,9 @@ load packageName' moduleName' symbol = Linker $ do
         )
 
 -- | Action that updates the package database. This uses the package environment
--- if it is specified. This can be specified with the @LOWARN_PACKAGE_ENV@
--- environment variable. If the package environment is not set, the package
--- database is instead updated by resetting the unit state and unit databases.
+-- if it is specified. This can be set with the @LOWARN_PACKAGE_ENV@ environment
+-- variable. If the package environment is not set, the package database is
+-- instead updated by resetting the unit state and unit databases.
 updatePackageDatabase :: Linker ()
 updatePackageDatabase = Linker $ do
   flags <- getSessionDynFlags

--- a/core/src/Lowarn/DynamicLinker.hs
+++ b/core/src/Lowarn/DynamicLinker.hs
@@ -103,10 +103,10 @@ load packageName' moduleName' symbol = Linker $ do
             return $ Just $ unsafeCoerce value
         )
 
--- | Update the package database. This uses the package environment if it is
--- specified with @LOWARN_PACKAGE_ENV@. If this environment variable is not set,
--- the package database is instead updated by resetting the unit state and unit
--- databases.
+-- | Action that updates the package database. This uses the package environment
+-- if it is specified. This can be specified with the @LOWARN_PACKAGE_ENV@
+-- environment variable. If the package environment is not set, the package
+-- database is instead updated by resetting the unit state and unit databases.
 updatePackageDatabase :: Linker ()
 updatePackageDatabase = Linker $ do
   flags <- getSessionDynFlags

--- a/core/src/Lowarn/Runtime.hs
+++ b/core/src/Lowarn/Runtime.hs
@@ -160,7 +160,8 @@ loadTransformer transformerId previousState =
       showTransformerModuleName . TransformerId._programName $ transformerId
     packageName = showTransformerPackageName transformerId
 
--- | Action that updates the package database.
+-- | Action that updates the package database, using
+-- 'DynamicLinker.updatePackageDatabase'.
 updatePackageDatabase :: Runtime ()
 updatePackageDatabase = liftLinker DynamicLinker.updatePackageDatabase
 

--- a/core/src/Lowarn/Runtime.hs
+++ b/core/src/Lowarn/Runtime.hs
@@ -35,9 +35,11 @@ where
 import Control.Concurrent (MVar, newEmptyMVar, tryPutMVar, tryTakeMVar)
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO)
+import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import Data.Maybe (isJust)
 import Lowarn.DynamicLinker (Linker, liftIO, load, runLinker)
+import qualified Lowarn.DynamicLinker as DynamicLinker (updatePackageDatabase)
 import Lowarn.ProgramName (showEntryPointModuleName, showTransformerModuleName)
 import Lowarn.TransformerId (TransformerId, showTransformerPackageName)
 import qualified Lowarn.TransformerId as TransformerId (_programName)
@@ -53,7 +55,7 @@ newtype UpdateSignal = UpdateSignal
 -- | Monad for loading versions of programs while handling signals and
 -- transferring state.
 newtype Runtime a = Runtime
-  { unRuntime :: ReaderT UpdateSignal IO a
+  { unRuntime :: ReaderT UpdateSignal Linker a
   }
   deriving (Functor, Applicative, Monad, MonadIO)
 
@@ -88,24 +90,30 @@ runRuntime runtime = do
       sigUSR2
       (Catch (void $ tryPutMVar updateSignal ()))
       Nothing
-  output <- runReaderT (unRuntime runtime) $ UpdateSignal updateSignal
+  output <-
+    runLinker $
+      runReaderT (unRuntime runtime) $
+        UpdateSignal updateSignal
   liftIO $ void $ installHandler sigUSR2 previousSignalHandler Nothing
   return output
 
+-- | Lift a computation from the 'Linker' monad.
+liftLinker :: Linker a -> Runtime a
+liftLinker = Runtime . lift
+
 withLinkedEntity :: String -> String -> String -> (a -> IO b) -> Runtime b
 withLinkedEntity packageName moduleName entityName f =
-  liftIO $ do
-    runLinker (load packageName moduleName entityName)
+  liftLinker $
+    load packageName moduleName entityName
       >>= maybe
-        ( error
-            ( printf
-                "Could not find entity %s in module %s in package %s"
-                entityName
-                moduleName
-                packageName
-            )
+        ( error $
+            printf
+              "Could not find entity %s in module %s in package %s"
+              entityName
+              moduleName
+              packageName
         )
-        f
+        (liftIO . f)
 
 -- | Action that loads and runs a given version of a program, producing the
 -- final state of the program when it finishes.
@@ -154,11 +162,7 @@ loadTransformer transformerId previousState =
 
 -- | Action that updates the package database.
 updatePackageDatabase :: Runtime ()
-updatePackageDatabase = return ()
-
--- | Lift a computation from the 'Linker' monad.
-liftLinker :: Linker a -> Runtime a
-liftLinker = Runtime . liftIO . runLinker
+updatePackageDatabase = liftLinker DynamicLinker.updatePackageDatabase
 
 -- | Return @True@ if the runtime has a program update that can be applied.
 isUpdateAvailable :: RuntimeData a -> IO Bool


### PR DESCRIPTION
Implement the `updatePackageDatabase` action in both `Runtime` and `DynamicLinker`. This means the `Runtime` monad can simply wrap the `Linker` monad, so there is only one GHC session per runtime.