### PR TITLE
Improve test timeouts

### DIFF
--- a/core-test/src/Test/Lowarn/Story.hs
+++ b/core-test/src/Test/Lowarn/Story.hs
@@ -133,7 +133,7 @@ runStory story getRuntime outputPath timeout = do
         Just () -> return ()
         Nothing ->
           writeLog fileHandle Error $
-            printf "Timeout of %d microseconds reached." timeout
+            printf "Timeout reached." timeout
 
     processStatusTimeout <-
       lookupEnv "CI"
@@ -148,7 +148,6 @@ runStory story getRuntime outputPath timeout = do
       (getProcessStatus True True processId)
       >>= \case
         Nothing -> do
-          writeLog fileHandle Error "Process did not end."
           signalProcess sigKILL processId
         Just Nothing -> do
           writeLog fileHandle Error "Process not available."
@@ -169,7 +168,7 @@ runStory story getRuntime outputPath timeout = do
     hClose inputWriteHandle
   where
     normalProcessStatusTimeout = 1000000
-    ciProcessStatusTimeout = 30000000
+    ciProcessStatusTimeout = 120000000
 
 -- | Action that queues a line to be read by the program.
 inputLine :: String -> Story ()

--- a/core-test/src/Test/Lowarn/Story.hs
+++ b/core-test/src/Test/Lowarn/Story.hs
@@ -148,6 +148,7 @@ runStory story getRuntime outputPath timeout = do
       (getProcessStatus True True processId)
       >>= \case
         Nothing -> do
+          writeLog fileHandle Error "Process did not end."
           signalProcess sigKILL processId
         Just Nothing -> do
           writeLog fileHandle Error "Process not available."

--- a/core-test/src/Test/Lowarn/Story.hs
+++ b/core-test/src/Test/Lowarn/Story.hs
@@ -131,9 +131,7 @@ runStory story getRuntime outputPath timeout = do
       )
       >>= \case
         Just () -> return ()
-        Nothing ->
-          writeLog fileHandle Error $
-            printf "Timeout reached." timeout
+        Nothing -> writeLog fileHandle Error "Timeout reached."
 
     processStatusTimeout <-
       lookupEnv "CI"

--- a/core-test/test/golden/Spec.Story.outputTimeout.golden
+++ b/core-test/test/golden/Spec.Story.outputTimeout.golden
@@ -1,5 +1,5 @@
 Output: Following:
 Output: ------
 Output: Input username of user to follow:
- Error: Timeout of 10000000 microseconds reached.
+ Error: Timeout reached.
  Error: Process did not end.

--- a/core-test/test/golden/Spec.Story.pipeOrderingWithOutputFirst.golden
+++ b/core-test/test/golden/Spec.Story.pipeOrderingWithOutputFirst.golden
@@ -1,5 +1,5 @@
 Output: Following:
 Output: ------
 Output: Input username of user to follow:
- Error: Timeout of 10000000 microseconds reached.
+ Error: Timeout reached.
  Error: Process did not end.


### PR DESCRIPTION
- Increase the CI process status timeout to 120 seconds.
- Do not include the length of the timeout in the timeout log message.