### PR TITLE
Change dynamic linker to static linker

### DIFF
--- a/arbitrary/lowarn-arbitrary.cabal
+++ b/arbitrary/lowarn-arbitrary.cabal
@@ -33,7 +33,7 @@ library
       Paths_lowarn_arbitrary
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-orphans -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -Wno-orphans
   build-depends:
       QuickCheck >=2.14 && <3
     , base >=4.7 && <5

--- a/arbitrary/package.yaml
+++ b/arbitrary/package.yaml
@@ -32,7 +32,6 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 - -Wno-orphans
-- -dynamic
 
 library:
   source-dirs: src

--- a/core-test/lowarn-test.cabal
+++ b/core-test/lowarn-test.cabal
@@ -31,7 +31,7 @@ library
       Paths_lowarn_test
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       QuickCheck
     , base >=4.7 && <5
@@ -57,7 +57,7 @@ test-suite lowarn-test
       Paths_lowarn_test
   hs-source-dirs:
       test
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       QuickCheck
     , base >=4.7 && <5

--- a/core-test/package.yaml
+++ b/core-test/package.yaml
@@ -35,7 +35,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 
 library:
   source-dirs: src

--- a/core/lowarn.cabal
+++ b/core/lowarn.cabal
@@ -25,7 +25,7 @@ source-repository head
 
 library
   exposed-modules:
-      Lowarn.DynamicLinker
+      Lowarn.Linker
       Lowarn.ParserCombinators
       Lowarn.Plugin
       Lowarn.ProgramName
@@ -37,7 +37,7 @@ library
       Paths_lowarn
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , ghc ==9.0.2

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -31,7 +31,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 
 library:
   source-dirs: src

--- a/core/src/Lowarn/Linker.hs
+++ b/core/src/Lowarn/Linker.hs
@@ -2,13 +2,13 @@
 {-# LANGUAGE LambdaCase #-}
 
 -- |
--- Module                  : Lowarn.Runtime
+-- Module                  : Lowarn.Linker
 -- SPDX-License-Identifier : MIT
 -- Stability               : experimental
 -- Portability             : non-portable (POSIX, GHC)
 --
 -- Module for interacting with GHC to link modules and load their entities.
-module Lowarn.DynamicLinker
+module Lowarn.Linker
   ( -- * Monad
     Linker,
     runLinker,
@@ -26,7 +26,6 @@ import GHC hiding (load, moduleName)
 import GHC.Data.FastString
 import GHC.Driver.Monad
 import GHC.Driver.Session
-import GHC.Driver.Ways
 import GHC.Paths (libdir)
 import GHC.Runtime.Interpreter
 import GHC.Runtime.Linker
@@ -57,10 +56,7 @@ runLinker linker =
               Nothing -> return flags
               Just lowarnPackageEnv -> do
                 interpretPackageEnv $ flags {packageEnv = Just lowarnPackageEnv}
-      void $
-        setSessionDynFlags $
-          addWay' WayDyn $
-            flags' {ghcMode = CompManager, ghcLink = LinkDynLib}
+      void $ setSessionDynFlags $ flags' {ghcLink = LinkStaticLib}
       liftIO . initDynLinker =<< getSession
       unLinker linker
 

--- a/core/src/Lowarn/Runtime.hs
+++ b/core/src/Lowarn/Runtime.hs
@@ -38,8 +38,8 @@ import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
 import Data.Maybe (isJust)
-import Lowarn.DynamicLinker (Linker, liftIO, load, runLinker)
-import qualified Lowarn.DynamicLinker as DynamicLinker (updatePackageDatabase)
+import Lowarn.Linker (Linker, liftIO, load, runLinker)
+import qualified Lowarn.Linker as Linker (updatePackageDatabase)
 import Lowarn.ProgramName (showEntryPointModuleName, showTransformerModuleName)
 import Lowarn.TransformerId (TransformerId, showTransformerPackageName)
 import qualified Lowarn.TransformerId as TransformerId (_programName)
@@ -161,9 +161,9 @@ loadTransformer transformerId previousState =
     packageName = showTransformerPackageName transformerId
 
 -- | Action that updates the package database, using
--- 'DynamicLinker.updatePackageDatabase'.
+-- 'Linker.updatePackageDatabase'.
 updatePackageDatabase :: Runtime ()
-updatePackageDatabase = liftLinker DynamicLinker.updatePackageDatabase
+updatePackageDatabase = liftLinker Linker.updatePackageDatabase
 
 -- | Return @True@ if the runtime has a program update that can be applied.
 isUpdateAvailable :: RuntimeData a -> IO Bool

--- a/examples/following/demo/following.cabal
+++ b/examples/following/demo/following.cabal
@@ -27,7 +27,7 @@ library
       Paths_following
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , lowarn
@@ -39,7 +39,7 @@ executable following-exe
       Paths_following
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , following

--- a/examples/following/demo/package.yaml
+++ b/examples/following/demo/package.yaml
@@ -22,7 +22,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 
 library:
   source-dirs: src

--- a/examples/following/transformers/0-1.0.0/lowarn-transformer-following-v0-v1v0v0.cabal
+++ b/examples/following/transformers/0-1.0.0/lowarn-transformer-following-v0-v1v0v0.cabal
@@ -26,7 +26,7 @@ library
       Paths_lowarn_transformer_following_v0_v1v0v0
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , lowarn

--- a/examples/following/transformers/0-1.0.0/package.yaml
+++ b/examples/following/transformers/0-1.0.0/package.yaml
@@ -23,7 +23,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 
 library:
   source-dirs: src

--- a/examples/following/transformers/1.0.0-2.0.0/lowarn-transformer-following-v1v0v0-v2v0v0.cabal
+++ b/examples/following/transformers/1.0.0-2.0.0/lowarn-transformer-following-v1v0v0-v2v0v0.cabal
@@ -26,7 +26,7 @@ library
       Paths_lowarn_transformer_following_v1v0v0_v2v0v0
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , containers

--- a/examples/following/transformers/1.0.0-2.0.0/package.yaml
+++ b/examples/following/transformers/1.0.0-2.0.0/package.yaml
@@ -26,7 +26,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 
 library:
   source-dirs: src

--- a/examples/following/transformers/2.0.0-3.0.0/lowarn-transformer-following-v2v0v0-v3v0v0.cabal
+++ b/examples/following/transformers/2.0.0-3.0.0/lowarn-transformer-following-v2v0v0-v3v0v0.cabal
@@ -26,7 +26,7 @@ library
       Paths_lowarn_transformer_following_v2v0v0_v3v0v0
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , lowarn

--- a/examples/following/transformers/2.0.0-3.0.0/package.yaml
+++ b/examples/following/transformers/2.0.0-3.0.0/package.yaml
@@ -24,7 +24,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 
 library:
   source-dirs: src

--- a/examples/following/versions/1.0.0/lowarn-version-following-v1v0v0.cabal
+++ b/examples/following/versions/1.0.0/lowarn-version-following-v1v0v0.cabal
@@ -27,7 +27,7 @@ library
       Paths_lowarn_version_following_v1v0v0
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic -fplugin Lowarn.Plugin
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fplugin Lowarn.Plugin
   build-depends:
       base >=4.7 && <5
     , lowarn

--- a/examples/following/versions/1.0.0/package.yaml
+++ b/examples/following/versions/1.0.0/package.yaml
@@ -23,7 +23,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 - -fplugin Lowarn.Plugin
 
 library:

--- a/examples/following/versions/2.0.0/lowarn-version-following-v2v0v0.cabal
+++ b/examples/following/versions/2.0.0/lowarn-version-following-v2v0v0.cabal
@@ -27,7 +27,7 @@ library
       Paths_lowarn_version_following_v2v0v0
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic -fplugin Lowarn.Plugin
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fplugin Lowarn.Plugin
   build-depends:
       base >=4.7 && <5
     , containers

--- a/examples/following/versions/2.0.0/package.yaml
+++ b/examples/following/versions/2.0.0/package.yaml
@@ -24,7 +24,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 - -fplugin Lowarn.Plugin
 
 library:

--- a/examples/following/versions/3.0.0/lowarn-version-following-v3v0v0.cabal
+++ b/examples/following/versions/3.0.0/lowarn-version-following-v3v0v0.cabal
@@ -27,7 +27,7 @@ library
       Paths_lowarn_version_following_v3v0v0
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -dynamic -fplugin Lowarn.Plugin
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fplugin Lowarn.Plugin
   build-depends:
       base >=4.7 && <5
     , lowarn

--- a/examples/following/versions/3.0.0/package.yaml
+++ b/examples/following/versions/3.0.0/package.yaml
@@ -23,7 +23,6 @@ ghc-options:
 - -Wmissing-home-modules
 - -Wpartial-fields
 - -Wredundant-constraints
-- -dynamic
 - -fplugin Lowarn.Plugin
 
 library:


### PR DESCRIPTION
Use runtime static runtime linking rather than runtime dynamic linking. This will make unloading easier. As dynamic linking no longer happens, `DynamicLinker.hs` has been renamed to `Linker.hs`.