### PR TITLE
Make story tests run in isolation

### DIFF
--- a/core-test/lowarn-test.cabal
+++ b/core-test/lowarn-test.cabal
@@ -27,6 +27,7 @@ library
   exposed-modules:
       Test.Lowarn.Property
       Test.Lowarn.Story
+      Test.Lowarn.Tasty
   other-modules:
       Paths_lowarn_test
   hs-source-dirs:

--- a/core-test/src/Test/Lowarn/Tasty.hs
+++ b/core-test/src/Test/Lowarn/Tasty.hs
@@ -1,0 +1,16 @@
+-- |
+-- Module                  : Test.Lowarn.Tasty
+-- SPDX-License-Identifier : MIT
+-- Stability               : stable
+-- Portability             : portable
+--
+-- Module for utilities for Tasty.
+module Test.Lowarn.Tasty (BinarySemaphore, withBinarySemaphore) where
+
+import Control.Concurrent (MVar, newMVar)
+import Test.Tasty (TestTree, withResource)
+
+type BinarySemaphore = MVar ()
+
+withBinarySemaphore :: (IO BinarySemaphore -> TestTree) -> TestTree
+withBinarySemaphore = withResource (newMVar ()) (const $ return ())

--- a/core-test/src/Test/Lowarn/Tasty.hs
+++ b/core-test/src/Test/Lowarn/Tasty.hs
@@ -4,13 +4,16 @@
 -- Stability               : stable
 -- Portability             : portable
 --
--- Module for utilities for Tasty.
+-- Module for utilities for using Tasty.
 module Test.Lowarn.Tasty (BinarySemaphore, withBinarySemaphore) where
 
 import Control.Concurrent (MVar, newMVar)
 import Test.Tasty (TestTree, withResource)
 
+-- | A binary semaphore.
 type BinarySemaphore = MVar ()
 
+-- | Run a test that requires a binary semaphore. The @'IO' a@ action will
+-- give the same semaphore every time it is run.
 withBinarySemaphore :: (IO BinarySemaphore -> TestTree) -> TestTree
 withBinarySemaphore = withResource (newMVar ()) (const $ return ())

--- a/core-test/test/Spec/ManualDsu.hs
+++ b/core-test/test/Spec/ManualDsu.hs
@@ -14,6 +14,7 @@ import Test.Lowarn.Story
     storyGoldenTest,
     updateProgram,
   )
+import Test.Lowarn.Tasty (BinarySemaphore)
 import Test.Tasty (TestTree, testGroup)
 
 getExampleRuntime :: (Handle, Handle) -> Runtime ()
@@ -29,7 +30,7 @@ getExampleRuntime handles =
 timeout :: Int
 timeout = 40000000
 
-successfulChain :: TestTree
+successfulChain :: IO BinarySemaphore -> TestTree
 successfulChain =
   storyGoldenTest
     (show 'successfulChain)
@@ -60,7 +61,7 @@ successfulChain =
       updateProgram
       inputLine "F#4567"
 
-duplicatedUpdateSignal :: TestTree
+duplicatedUpdateSignal :: IO BinarySemaphore -> TestTree
 duplicatedUpdateSignal =
   storyGoldenTest
     (show 'duplicatedUpdateSignal)
@@ -84,10 +85,11 @@ duplicatedUpdateSignal =
       _ <- outputLines 6
       return ()
 
-manualDsuTests :: TestTree
-manualDsuTests =
+manualDsuTests :: IO BinarySemaphore -> TestTree
+manualDsuTests binarySemaphoreAction =
   testGroup
     "Manual DSU"
-    [ successfulChain,
-      duplicatedUpdateSignal
-    ]
+    $ [ successfulChain,
+        duplicatedUpdateSignal
+      ]
+      <*> [binarySemaphoreAction]

--- a/core-test/test/Spec/Story.hs
+++ b/core-test/test/Spec/Story.hs
@@ -13,6 +13,7 @@ import Test.Lowarn.Story
     storyGoldenTest,
     writeInfo,
   )
+import Test.Lowarn.Tasty (BinarySemaphore)
 import Test.Tasty (TestTree, testGroup)
 
 getExampleRuntime :: (Handle, Handle) -> Runtime ()
@@ -24,7 +25,7 @@ getExampleRuntime handles =
 timeout :: Int
 timeout = 10000000
 
-inputTimeout :: TestTree
+inputTimeout :: IO BinarySemaphore -> TestTree
 inputTimeout =
   storyGoldenTest
     (show 'inputTimeout)
@@ -32,7 +33,7 @@ inputTimeout =
     (void $ outputLines 3)
     timeout
 
-outputTimeout :: TestTree
+outputTimeout :: IO BinarySemaphore -> TestTree
 outputTimeout =
   storyGoldenTest
     (show 'outputTimeout)
@@ -40,7 +41,7 @@ outputTimeout =
     (void $ outputLines 7)
     timeout
 
-pipeOrderingWithInputFirst :: TestTree
+pipeOrderingWithInputFirst :: IO BinarySemaphore -> TestTree
 pipeOrderingWithInputFirst =
   storyGoldenTest
     (show 'pipeOrderingWithInputFirst)
@@ -48,7 +49,7 @@ pipeOrderingWithInputFirst =
     (void $ inputLine "A" >> outputLines 7)
     timeout
 
-pipeOrderingWithOutputFirst :: TestTree
+pipeOrderingWithOutputFirst :: IO BinarySemaphore -> TestTree
 pipeOrderingWithOutputFirst =
   storyGoldenTest
     (show 'pipeOrderingWithOutputFirst)
@@ -56,7 +57,7 @@ pipeOrderingWithOutputFirst =
     (outputLines 7 >> inputLine "A")
     timeout
 
-info :: TestTree
+info :: IO BinarySemaphore -> TestTree
 info =
   storyGoldenTest
     (show 'info)
@@ -64,13 +65,14 @@ info =
     (writeInfo "Test")
     timeout
 
-storyTests :: TestTree
-storyTests =
+storyTests :: IO BinarySemaphore -> TestTree
+storyTests binarySemaphoreAction =
   testGroup
     "Story framework"
-    [ inputTimeout,
-      outputTimeout,
-      pipeOrderingWithInputFirst,
-      pipeOrderingWithOutputFirst,
-      info
-    ]
+    $ [ inputTimeout,
+        outputTimeout,
+        pipeOrderingWithInputFirst,
+        pipeOrderingWithOutputFirst,
+        info
+      ]
+      <*> [binarySemaphoreAction]


### PR DESCRIPTION
Adds a binary semaphore and a dependency in the Tasty test suite such that each test that runs a story does not run with any other test. This method means that tests that do not run stories can still be run in parallel.