### PR TITLE
Remove the "Process did not end" error

### DIFF
--- a/core-test/lowarn-test.cabal
+++ b/core-test/lowarn-test.cabal
@@ -18,6 +18,13 @@ license:        MIT
 build-type:     Simple
 extra-source-files:
     README.md
+    test/golden/Spec.ManualDsu.duplicatedUpdateSignal.golden
+    test/golden/Spec.ManualDsu.successfulChain.golden
+    test/golden/Spec.Story.info.golden
+    test/golden/Spec.Story.inputTimeout.golden
+    test/golden/Spec.Story.outputTimeout.golden
+    test/golden/Spec.Story.pipeOrderingWithInputFirst.golden
+    test/golden/Spec.Story.pipeOrderingWithOutputFirst.golden
 
 source-repository head
   type: git

--- a/core-test/src/Test/Lowarn/Story.hs
+++ b/core-test/src/Test/Lowarn/Story.hs
@@ -28,12 +28,11 @@ where
 
 import Control.Concurrent (threadDelay, withMVar)
 import Control.Exception (SomeException, catch, displayException)
-import Control.Monad (replicateM)
+import Control.Monad (replicateM, when)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Control.Monad.Trans.Reader (ReaderT, asks, runReaderT)
-import Data.Functor ((<&>))
+import Data.IORef (newIORef, readIORef, writeIORef)
 import Lowarn.Runtime (Runtime, runRuntime)
-import System.Environment (lookupEnv)
 import System.Exit (ExitCode (ExitFailure, ExitSuccess))
 import System.FilePath ((<.>), (</>))
 import System.IO
@@ -114,6 +113,8 @@ runStory story getRuntime outputPath timeout = do
     hSetBinaryMode fileHandle True
     hSetBuffering fileHandle LineBuffering
 
+    shouldWriteExceptionsRef <- newIORef True
+
     processId <-
       forkProcessWithUnmask $ \unmask ->
         catch
@@ -121,10 +122,13 @@ runStory story getRuntime outputPath timeout = do
               runRuntime $
                 getRuntime (inputReadHandle, outputWriteHandle)
           )
-          ( \exception ->
-              writeLog fileHandle Error $
-                displayException (exception :: SomeException)
+          ( \exception -> do
+              shouldWriteExceptions <- readIORef shouldWriteExceptionsRef
+              when shouldWriteExceptions $
+                writeLog fileHandle Error $
+                  displayException (exception :: SomeException)
           )
+
     Timeout.timeout
       timeout
       ( runReaderT (unStory story) $
@@ -134,41 +138,26 @@ runStory story getRuntime outputPath timeout = do
         Just () -> return ()
         Nothing -> writeLog fileHandle Error "Timeout reached."
 
-    processStatusTimeout <-
-      lookupEnv "CI"
-        <&> ( \case
-                Nothing -> normalProcessStatusTimeout
-                Just "" -> normalProcessStatusTimeout
-                Just _ -> ciProcessStatusTimeout
-            )
-
-    Timeout.timeout
-      processStatusTimeout
-      (getProcessStatus True True processId)
+    getProcessStatus False True processId
       >>= \case
-        Nothing -> do
-          writeLog fileHandle Error "Process did not end."
-          signalProcess sigKILL processId
-        Just Nothing -> do
-          writeLog fileHandle Error "Process not available."
-          signalProcess sigKILL processId
-        Just (Just (Exited ExitSuccess)) -> return ()
-        Just (Just (Exited (ExitFailure exitCode))) ->
+        Nothing -> return ()
+        Just (Exited ExitSuccess) -> return ()
+        Just (Exited (ExitFailure exitCode)) ->
           writeLog fileHandle Error $
             printf "Process exited with exit code %d." exitCode
-        Just (Just (Terminated signal _)) ->
+        Just (Terminated signal _) ->
           writeLog fileHandle Error $
             printf "Process terminated by signal %s." $
               show signal
-        Just (Just (Stopped signal)) ->
+        Just (Stopped signal) ->
           writeLog fileHandle Error $
             printf "Process stopped by signal %s." $
               show signal
 
+    writeIORef shouldWriteExceptionsRef False
+    signalProcess sigKILL processId
+
     hClose inputWriteHandle
-  where
-    normalProcessStatusTimeout = 1000000
-    ciProcessStatusTimeout = 120000000
 
 -- | Action that queues a line to be read by the program.
 inputLine :: String -> Story ()

--- a/core-test/test/golden/Spec.ManualDsu.duplicatedUpdateSignal.golden
+++ b/core-test/test/golden/Spec.ManualDsu.duplicatedUpdateSignal.golden
@@ -24,4 +24,3 @@ Output: B#9481
 Output: C#1234
 Output: ------
 Output: Input nickname of user to follow:
- Error: Process did not end.

--- a/core-test/test/golden/Spec.Story.inputTimeout.golden
+++ b/core-test/test/golden/Spec.Story.inputTimeout.golden
@@ -1,4 +1,3 @@
 Output: Following:
 Output: ------
 Output: Input username of user to follow:
- Error: Process did not end.

--- a/core-test/test/golden/Spec.Story.outputTimeout.golden
+++ b/core-test/test/golden/Spec.Story.outputTimeout.golden
@@ -2,4 +2,3 @@ Output: Following:
 Output: ------
 Output: Input username of user to follow:
  Error: Timeout reached.
- Error: Process did not end.

--- a/core-test/test/golden/Spec.Story.pipeOrderingWithInputFirst.golden
+++ b/core-test/test/golden/Spec.Story.pipeOrderingWithInputFirst.golden
@@ -6,4 +6,3 @@ Output: Following:
 Output: A
 Output: ------
 Output: Input username of user to follow:
- Error: Process did not end.

--- a/core-test/test/golden/Spec.Story.pipeOrderingWithOutputFirst.golden
+++ b/core-test/test/golden/Spec.Story.pipeOrderingWithOutputFirst.golden
@@ -2,4 +2,3 @@ Output: Following:
 Output: ------
 Output: Input username of user to follow:
  Error: Timeout reached.
- Error: Process did not end.


### PR DESCRIPTION
Stops printing to golden files when the process does not end quickly enough, as it is not possible to tell how long this should take.