### PR TITLE
Add package unloading

### DIFF
--- a/core/src/Lowarn/VersionNumber.hs
+++ b/core/src/Lowarn/VersionNumber.hs
@@ -106,7 +106,7 @@ showEntryPointExport = ("hs_entryPoint_" <>) . showWithLetters
 --
 -- ==== __Examples__
 --
--- >>> showEntryPointExport (fromJust $ mkVersionNumber (1 :| [2, 3])) (fromJust $ mkVersionNumber (1 :| [2, 3]))
+-- >>> showTransformerExport (fromJust $ mkVersionNumber (1 :| [2, 3])) (fromJust $ mkVersionNumber (1 :| [2, 3]))
 -- "hs_transformer_v1v2v3_v1v2v4"
 showTransformerExport :: VersionNumber -> VersionNumber -> String
 showTransformerExport previousVersionNumber nextVersionNUmber =

--- a/core/src/Lowarn/VersionNumber.hs
+++ b/core/src/Lowarn/VersionNumber.hs
@@ -106,7 +106,7 @@ showEntryPointExport = ("hs_entryPoint_" <>) . showWithLetters
 --
 -- ==== __Examples__
 --
--- >>> showTransformerExport (fromJust $ mkVersionNumber (1 :| [2, 3])) (fromJust $ mkVersionNumber (1 :| [2, 3]))
+-- >>> showTransformerExport (fromJust $ mkVersionNumber (1 :| [2, 3])) (fromJust $ mkVersionNumber (1 :| [2, 4]))
 -- "hs_transformer_v1v2v3_v1v2v4"
 showTransformerExport :: VersionNumber -> VersionNumber -> String
 showTransformerExport previousVersionNumber nextVersionNUmber =

--- a/core/src/Lowarn/VersionNumber.hs
+++ b/core/src/Lowarn/VersionNumber.hs
@@ -18,6 +18,10 @@ module Lowarn.VersionNumber
     showWithLetters,
     parseWithDots,
     parseWithLetters,
+
+    -- * Exports
+    showEntryPointExport,
+    showTransformerExport,
   )
 where
 
@@ -86,6 +90,30 @@ showWithDots = showWithSeparator "."
 -- "v1v2v3"
 showWithLetters :: VersionNumber -> String
 showWithLetters = ("v" <>) . showWithSeparator "v"
+
+-- | Show the identifier that is used to export the entry point of a program's
+-- version that corresponds to a given version number.
+--
+-- ==== __Examples__
+--
+-- >>> showEntryPointExport (fromJust $ mkVersionNumber (1 :| [2, 3]))
+-- "hs_entryPoint_v1v2v3"
+showEntryPointExport :: VersionNumber -> String
+showEntryPointExport = ("hs_entryPoint_" <>) . showWithLetters
+
+-- | Show the identifier that is used to export a state transformer from one
+-- version of a program to another, with the version's version numbers given.
+--
+-- ==== __Examples__
+--
+-- >>> showEntryPointExport (fromJust $ mkVersionNumber (1 :| [2, 3])) (fromJust $ mkVersionNumber (1 :| [2, 3]))
+-- "hs_transformer_v1v2v3_v1v2v4"
+showTransformerExport :: VersionNumber -> VersionNumber -> String
+showTransformerExport previousVersionNumber nextVersionNUmber =
+  "hs_transformer_"
+    <> showWithLetters previousVersionNumber
+    <> "_"
+    <> showWithLetters nextVersionNUmber
 
 parseWithSeparator :: Char -> ReadP VersionNumber
 parseWithSeparator separator =

--- a/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
@@ -3,6 +3,7 @@ module Transformer_following
   )
 where
 
+import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer (Transformer))
 import Lowarn.ExampleProgram.Following (State (State))
 import System.IO (Handle)
@@ -11,3 +12,9 @@ transformer :: Transformer (Handle, Handle) State
 transformer = Transformer $
   \(inHandle, outHandle) ->
     return $ Just $ State [] inHandle outHandle
+
+foreign export ccall "hs_transformer"
+  hsTransformer :: IO (StablePtr (Transformer (Handle, Handle) State))
+
+hsTransformer :: IO (StablePtr (Transformer (Handle, Handle) State))
+hsTransformer = newStablePtr transformer

--- a/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
@@ -13,7 +13,7 @@ transformer = Transformer $
   \(inHandle, outHandle) ->
     return $ Just $ State [] inHandle outHandle
 
-foreign export ccall "hs_transformer"
+foreign export ccall "hs_transformer_v0_v1v0v0"
   hsTransformer :: IO (StablePtr (Transformer (Handle, Handle) State))
 
 hsTransformer :: IO (StablePtr (Transformer (Handle, Handle) State))

--- a/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
@@ -7,6 +7,7 @@ where
 
 import Control.Arrow (first)
 import qualified Data.Sequence as Seq
+import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer (Transformer))
 import System.Random (mkStdGen, randomR)
 import System.Random.Stateful (applyIOGen, newIOGenM)
@@ -27,3 +28,11 @@ transformer = Transformer $
           )
           users
     return $ Just $ NextVersion.State users' inHandle outHandle
+
+foreign export ccall "hs_transformer"
+  hsTransformer ::
+    IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
+
+hsTransformer ::
+  IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
+hsTransformer = newStablePtr transformer

--- a/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
@@ -29,7 +29,7 @@ transformer = Transformer $
           users
     return $ Just $ NextVersion.State users' inHandle outHandle
 
-foreign export ccall "hs_transformer"
+foreign export ccall "hs_transformer_v1v0v0_v2v0v0"
   hsTransformer ::
     IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
 

--- a/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
@@ -6,6 +6,7 @@ module Transformer_following
 where
 
 import Data.Foldable (toList)
+import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer (Transformer))
 import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
 import qualified "lowarn-version-following-v3v0v0" Lowarn.ExampleProgram.Following as NextVersion
@@ -22,3 +23,11 @@ transformer = Transformer $
           )
           inHandle
           outHandle
+
+foreign export ccall "hs_transformer"
+  hsTransformer ::
+    IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
+
+hsTransformer ::
+  IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
+hsTransformer = newStablePtr transformer

--- a/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
@@ -24,7 +24,7 @@ transformer = Transformer $
           inHandle
           outHandle
 
-foreign export ccall "hs_transformer"
+foreign export ccall "hs_transformer_v2v0v0_v3v0v0"
   hsTransformer ::
     IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
 

--- a/examples/following/versions/1.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/1.0.0/src/EntryPoint_following.hs
@@ -4,6 +4,7 @@ module EntryPoint_following
 where
 
 import Data.Maybe (fromMaybe)
+import Foreign (StablePtr, newStablePtr)
 import Lowarn (EntryPoint (..), lastState)
 import Lowarn.ExampleProgram.Following (State (State), eventLoop)
 import System.IO
@@ -16,3 +17,9 @@ entryPoint = EntryPoint $
   \runtimeData ->
     eventLoop runtimeData $
       fromMaybe (State [] stdin stdout) (lastState runtimeData)
+
+foreign export ccall "hs_entryPoint"
+  hsEntryPoint :: IO (StablePtr (EntryPoint State))
+
+hsEntryPoint :: IO (StablePtr (EntryPoint State))
+hsEntryPoint = newStablePtr entryPoint

--- a/examples/following/versions/1.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/1.0.0/src/EntryPoint_following.hs
@@ -18,7 +18,7 @@ entryPoint = EntryPoint $
     eventLoop runtimeData $
       fromMaybe (State [] stdin stdout) (lastState runtimeData)
 
-foreign export ccall "hs_entryPoint"
+foreign export ccall "hs_entryPoint_v1v0v0"
   hsEntryPoint :: IO (StablePtr (EntryPoint State))
 
 hsEntryPoint :: IO (StablePtr (EntryPoint State))

--- a/examples/following/versions/2.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/2.0.0/src/EntryPoint_following.hs
@@ -19,7 +19,7 @@ entryPoint = EntryPoint $
     eventLoop runtimeData $
       fromMaybe (State Seq.empty stdin stdout) (lastState runtimeData)
 
-foreign export ccall "hs_entryPoint"
+foreign export ccall "hs_entryPoint_v2v0v0"
   hsEntryPoint :: IO (StablePtr (EntryPoint State))
 
 hsEntryPoint :: IO (StablePtr (EntryPoint State))

--- a/examples/following/versions/2.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/2.0.0/src/EntryPoint_following.hs
@@ -5,6 +5,7 @@ where
 
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq
+import Foreign (StablePtr, newStablePtr)
 import Lowarn (EntryPoint (..), lastState)
 import Lowarn.ExampleProgram.Following (State (State), eventLoop)
 import System.IO
@@ -17,3 +18,9 @@ entryPoint = EntryPoint $
   \runtimeData ->
     eventLoop runtimeData $
       fromMaybe (State Seq.empty stdin stdout) (lastState runtimeData)
+
+foreign export ccall "hs_entryPoint"
+  hsEntryPoint :: IO (StablePtr (EntryPoint State))
+
+hsEntryPoint :: IO (StablePtr (EntryPoint State))
+hsEntryPoint = newStablePtr entryPoint

--- a/examples/following/versions/3.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/3.0.0/src/EntryPoint_following.hs
@@ -4,6 +4,7 @@ module EntryPoint_following
 where
 
 import Data.Maybe (fromMaybe)
+import Foreign (StablePtr, newStablePtr)
 import Lowarn (EntryPoint (..), lastState)
 import Lowarn.ExampleProgram.Following (State (State), eventLoop)
 import System.IO
@@ -16,3 +17,9 @@ entryPoint = EntryPoint $
   \runtimeData ->
     eventLoop runtimeData $
       fromMaybe (State [] stdin stdout) (lastState runtimeData)
+
+foreign export ccall "hs_entryPoint"
+  hsEntryPoint :: IO (StablePtr (EntryPoint State))
+
+hsEntryPoint :: IO (StablePtr (EntryPoint State))
+hsEntryPoint = newStablePtr entryPoint

--- a/examples/following/versions/3.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/3.0.0/src/EntryPoint_following.hs
@@ -18,7 +18,7 @@ entryPoint = EntryPoint $
     eventLoop runtimeData $
       fromMaybe (State [] stdin stdout) (lastState runtimeData)
 
-foreign export ccall "hs_entryPoint"
+foreign export ccall "hs_entryPoint_v3v0v0"
   hsEntryPoint :: IO (StablePtr (EntryPoint State))
 
 hsEntryPoint :: IO (StablePtr (EntryPoint State))

--- a/runtime/lowarn-runtime.cabal
+++ b/runtime/lowarn-runtime.cabal
@@ -33,7 +33,8 @@ library
       src
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
-      base >=4.7 && <5
+      Glob >=0.10.2 && <0.11
+    , base >=4.7 && <5
     , ghc ==9.0.2
     , ghc-paths
     , lowarn

--- a/runtime/lowarn-runtime.cabal
+++ b/runtime/lowarn-runtime.cabal
@@ -35,6 +35,7 @@ library
   build-depends:
       Glob >=0.10.2 && <0.11
     , base >=4.7 && <5
+    , containers
     , ghc ==9.0.2
     , ghc-paths
     , lowarn

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -16,6 +16,7 @@ description:         Please see the README on GitHub at <https://github.com/jona
 
 dependencies:
 - base >= 4.7 && < 5
+- containers
 - ghc == 9.0.2
 - ghc-paths
 - Glob >= 0.10.2 && < 0.11

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -18,6 +18,7 @@ dependencies:
 - base >= 4.7 && < 5
 - ghc == 9.0.2
 - ghc-paths
+- Glob >= 0.10.2 && < 0.11
 - lowarn
 - transformers
 - unix

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -23,7 +23,10 @@ where
 import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO)
 import Data.List (minimumBy)
+import Data.Maybe (mapMaybe)
 import Data.Ord (comparing)
+import Data.Set (Set)
+import qualified Data.Set as Set
 import GHC hiding (load, moduleName)
 import GHC.Data.FastString
 import GHC.Driver.Monad

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -149,7 +149,7 @@ findArchiveFile unitInfo = do
     _ : _ -> Just $ minimumBy (comparing length) archiveFiles
   where
     searchDirs = unitLibraryDirs unitInfo
-    packageName = show $ unPackageName $ unitPackageName unitInfo
+    packageName = unpackFS $ unPackageName $ unitPackageName unitInfo
     compOptions =
       CompOptions
         { characterClasses = False,

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -104,7 +104,9 @@ load packageName' moduleName' symbol = Linker $ do
             Set.fromList . catMaybes
               <$> sequence
                 [ liftIO $ findArchiveFile dependencyUnitInfo
-                  | dependencyUnitInfo <- findDependencyUnitInfo flags unitInfo
+                  | dependencyUnitInfo <- findDependencyUnitInfo flags unitInfo,
+                    unitId dependencyUnitInfo
+                      `notElem` preloadUnits (unitState flags)
                 ]
 
           put nextArchiveFiles

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -30,7 +30,13 @@ import Data.Maybe (catMaybes, mapMaybe)
 import Data.Ord (comparing)
 import Data.Set (Set)
 import qualified Data.Set as Set
-import Foreign (FunPtr, StablePtr, castPtrToFunPtr, deRefStablePtr, freeStablePtr)
+import Foreign
+  ( FunPtr,
+    StablePtr,
+    castPtrToFunPtr,
+    deRefStablePtr,
+    freeStablePtr,
+  )
 import GHC hiding (load, moduleName)
 import GHC.Data.FastString
 import GHC.Driver.Monad

--- a/runtime/src/Lowarn/Runtime.hs
+++ b/runtime/src/Lowarn/Runtime.hs
@@ -87,7 +87,7 @@ loadVersion versionId mPreviousState = do
   withLinkedEntity
     packageName
     moduleName
-    "entryPoint"
+    "hs_entryPoint"
     ( \entryPoint ->
         unEntryPoint entryPoint $
           RuntimeData updateSignalRegister (UpdateInfo <$> mPreviousState)
@@ -109,7 +109,7 @@ loadTransformer transformerId previousState =
   withLinkedEntity
     packageName
     moduleName
-    "transformer"
+    "hs_transformer"
     (`unTransformer` previousState)
   where
     moduleName =

--- a/runtime/src/Lowarn/Runtime.hs
+++ b/runtime/src/Lowarn/Runtime.hs
@@ -22,7 +22,15 @@ import Control.Monad (void)
 import Control.Monad.IO.Class (MonadIO)
 import Control.Monad.Trans.Class (lift)
 import Control.Monad.Trans.Reader (ReaderT, ask, runReaderT)
-import Lowarn (EntryPoint (unEntryPoint), RuntimeData (RuntimeData), Transformer (unTransformer), UpdateInfo (UpdateInfo), UpdateSignalRegister, fillUpdateSignalRegister, mkUpdateSignalRegister)
+import Lowarn
+  ( EntryPoint (unEntryPoint),
+    RuntimeData (RuntimeData),
+    Transformer (unTransformer),
+    UpdateInfo (UpdateInfo),
+    UpdateSignalRegister,
+    fillUpdateSignalRegister,
+    mkUpdateSignalRegister,
+  )
 import Lowarn.Linker (Linker, liftIO, load, runLinker)
 import qualified Lowarn.Linker as Linker (updatePackageDatabase)
 import Lowarn.ProgramName (showEntryPointModuleName, showTransformerModuleName)


### PR DESCRIPTION
This PR uses the object linker to manually load archive files. This allows them to also be unloaded. For the new linker to work, C FFI exports have been added to the project.

Closes #12.