### PR TITLE
Fix tests and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -58,7 +58,7 @@ jobs:
         run: cabal haddock lowarn lowarn-runtime lowarn-plugin lowarn-arbitrary lowarn-test
   stack:
     runs-on: ubuntu-latest
-    needs: cabal
+    needs: ormolu
     strategy:
       matrix:
         ghc: ["9.0.2"]

--- a/test/test/Spec/Story.hs
+++ b/test/test/Spec/Story.hs
@@ -23,7 +23,7 @@ getExampleRuntime handles =
       >>= loadVersion followingVersionId_1
 
 timeout :: Int
-timeout = 10000000
+timeout = 40000000
 
 inputTimeout :: IO BinarySemaphore -> TestTree
 inputTimeout =


### PR DESCRIPTION
Increases the timeout for the story tests, and allow Stack and Cabal CI to run at the same time.