### PR TITLE
Fix portability

### DIFF
--- a/core/src/Lowarn.hs
+++ b/core/src/Lowarn.hs
@@ -5,7 +5,7 @@
 -- Module                  : Lowarn
 -- SPDX-License-Identifier : MIT
 -- Stability               : experimental
--- Portability             : portable
+-- Portability             : non-portable (GHC)
 --
 -- Module for interacting with Lowarn.
 module Lowarn

--- a/core/src/Lowarn/VersionNumber.hs
+++ b/core/src/Lowarn/VersionNumber.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE LambdaCase #-}
-
 -- |
 -- Module                  : Lowarn.VersionNumber
 -- SPDX-License-Identifier : MIT
@@ -116,9 +114,10 @@ showTransformerExport previousVersionNumber nextVersionNUmber =
     <> showWithLetters nextVersionNUmber
 
 parseWithSeparator :: Char -> ReadP VersionNumber
-parseWithSeparator separator =
-  sepBy1 (read <$> munch1 isDigit) (char separator) >>= \case
-    (x : xs) -> return $ VersionNumber (x :| xs)
+parseWithSeparator separator = do
+  xs <- sepBy1 (read <$> munch1 isDigit) (char separator)
+  case xs of
+    (y : ys) -> return $ VersionNumber (y :| ys)
     [] -> pfail
 
 -- | A parser for version numbers given as strings of dot-separated non-negative


### PR DESCRIPTION
Mark 'Lowarn' as non-portable and make 'Lowarn.VersionNumber' actually portable.