### PR TITLE
Improve examples

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -3,4 +3,5 @@ write-ghc-environment-files: always
 packages:
     */*.cabal
   , examples/*/demo/*.cabal
-  , examples/*/{versions,transformers}/*/*.cabal
+  , examples/*/versions/*/*.cabal
+  , examples/*/transformers/*/*.cabal

--- a/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
@@ -1,7 +1,4 @@
-module Transformer_following
-  ( transformer,
-  )
-where
+module Transformer_following () where
 
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer (Transformer))

--- a/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
@@ -4,10 +4,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Transformer_following
-  ( transformer,
-  )
-where
+module Transformer_following () where
 
 import Control.Arrow (first)
 import Data.Sequence (Seq)

--- a/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
@@ -4,10 +4,7 @@
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Transformer_following
-  ( transformer,
-  )
-where
+module Transformer_following () where
 
 import Control.Arrow
 import Data.Foldable (toList)

--- a/examples/following/versions/1.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/1.0.0/src/EntryPoint_following.hs
@@ -1,7 +1,4 @@
-module EntryPoint_following
-  ( entryPoint,
-  )
-where
+module EntryPoint_following () where
 
 import Data.Maybe (fromMaybe)
 import Foreign (StablePtr, newStablePtr)

--- a/examples/following/versions/2.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/2.0.0/src/EntryPoint_following.hs
@@ -1,7 +1,4 @@
-module EntryPoint_following
-  ( entryPoint,
-  )
-where
+module EntryPoint_following () where
 
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq

--- a/examples/following/versions/3.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/3.0.0/src/EntryPoint_following.hs
@@ -1,7 +1,4 @@
-module EntryPoint_following
-  ( entryPoint,
-  )
-where
+module EntryPoint_following () where
 
 import Data.Maybe (fromMaybe)
 import Foreign (StablePtr, newStablePtr)

--- a/examples/manual-following/transformers/0-1.0.0/src/Transformer_manual_following.hs
+++ b/examples/manual-following/transformers/0-1.0.0/src/Transformer_manual_following.hs
@@ -1,7 +1,4 @@
-module Transformer_manual_following
-  ( transformer,
-  )
-where
+module Transformer_manual_following () where
 
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer (Transformer))

--- a/examples/manual-following/transformers/1.0.0-2.0.0/src/Transformer_manual_following.hs
+++ b/examples/manual-following/transformers/1.0.0-2.0.0/src/Transformer_manual_following.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE PackageImports #-}
 
-module Transformer_manual_following
-  ( transformer,
-  )
-where
+module Transformer_manual_following () where
 
 import Control.Arrow (first)
 import qualified Data.Sequence as Seq

--- a/examples/manual-following/transformers/2.0.0-3.0.0/src/Transformer_manual_following.hs
+++ b/examples/manual-following/transformers/2.0.0-3.0.0/src/Transformer_manual_following.hs
@@ -1,9 +1,6 @@
 {-# LANGUAGE PackageImports #-}
 
-module Transformer_manual_following
-  ( transformer,
-  )
-where
+module Transformer_manual_following () where
 
 import Data.Foldable (toList)
 import Foreign (StablePtr, newStablePtr)

--- a/examples/manual-following/versions/1.0.0/src/EntryPoint_manual_following.hs
+++ b/examples/manual-following/versions/1.0.0/src/EntryPoint_manual_following.hs
@@ -1,7 +1,4 @@
-module EntryPoint_manual_following
-  ( entryPoint,
-  )
-where
+module EntryPoint_manual_following () where
 
 import Data.Maybe (fromMaybe)
 import Foreign (StablePtr, newStablePtr)

--- a/examples/manual-following/versions/2.0.0/src/EntryPoint_manual_following.hs
+++ b/examples/manual-following/versions/2.0.0/src/EntryPoint_manual_following.hs
@@ -1,7 +1,4 @@
-module EntryPoint_manual_following
-  ( entryPoint,
-  )
-where
+module EntryPoint_manual_following () where
 
 import Data.Maybe (fromMaybe)
 import qualified Data.Sequence as Seq

--- a/examples/manual-following/versions/3.0.0/src/EntryPoint_manual_following.hs
+++ b/examples/manual-following/versions/3.0.0/src/EntryPoint_manual_following.hs
@@ -1,7 +1,4 @@
-module EntryPoint_manual_following
-  ( entryPoint,
-  )
-where
+module EntryPoint_manual_following () where
 
 import Data.Maybe (fromMaybe)
 import Foreign (StablePtr, newStablePtr)


### PR DESCRIPTION
- Remove unnecessary exports in entry point and transformer files.
- Split `examples/*/{versions,transformers}/*/*.cabal` into `examples/*/versions/*/*.cabal` and `examples/*/transformers/*/*.cabal` for better IDE support.