### PR TITLE
Add strict transformers and don't retain CAFs

### DIFF
--- a/examples/following/demo/app/Main.hs
+++ b/examples/following/demo/app/Main.hs
@@ -18,8 +18,14 @@ main =
 
     updatePackageDatabase
     state2 <-
-      loadTransformerAndVersion followingTransformerId_1_2 followingVersionId_2 state1
+      loadTransformerAndVersion
+        followingTransformerId_1_2
+        followingVersionId_2
+        state1
 
     updatePackageDatabase
     void $
-      loadTransformerAndVersion followingTransformerId_2_3 followingVersionId_3 state2
+      loadTransformerAndVersion
+        followingTransformerId_2_3
+        followingVersionId_3
+        state2

--- a/examples/following/demo/app/Main.hs
+++ b/examples/following/demo/app/Main.hs
@@ -1,43 +1,25 @@
 module Main (main) where
 
-import Control.Concurrent (threadDelay)
-import Control.Exception (evaluate)
 import Control.Monad (void)
 import Lowarn.ExampleProgram.Following.TransformerId
 import Lowarn.ExampleProgram.Following.VersionId
 import Lowarn.Runtime
-  ( Runtime,
-    liftIO,
-    loadTransformer,
+  ( loadTransformerAndVersion,
     loadVersion,
     runRuntime,
     updatePackageDatabase,
   )
-import System.IO (hReady, stdin)
 
 main :: IO ()
 main =
   runRuntime $ do
-    state1' <- state1''
+    state1 <-
+      loadVersion followingVersionId_1 Nothing
 
-    _ <- liftIO getLine
-
-    state2 <- loadVersion followingVersionId_2 state1'
+    updatePackageDatabase
+    state2 <-
+      loadTransformerAndVersion followingTransformerId_1_2 followingVersionId_2 state1
 
     updatePackageDatabase
     void $
-      loadVersion followingVersionId_3
-        =<< loadTransformer followingTransformerId_2_3 state2
-
-state1'' :: Runtime (Maybe a)
-state1'' = do
-  state1 <-
-    loadVersion followingVersionId_1 Nothing
-
-  updatePackageDatabase
-  liftIO . evaluate
-    =<< ( ( loadTransformer $!
-              followingTransformerId_1_2
-          )
-            $! state1
-        )
+      loadTransformerAndVersion followingTransformerId_2_3 followingVersionId_3 state2

--- a/examples/following/demo/app/Main.hs
+++ b/examples/following/demo/app/Main.hs
@@ -1,27 +1,43 @@
 module Main (main) where
 
+import Control.Concurrent (threadDelay)
+import Control.Exception (evaluate)
 import Control.Monad (void)
 import Lowarn.ExampleProgram.Following.TransformerId
 import Lowarn.ExampleProgram.Following.VersionId
 import Lowarn.Runtime
-  ( loadTransformer,
+  ( Runtime,
+    liftIO,
+    loadTransformer,
     loadVersion,
     runRuntime,
     updatePackageDatabase,
   )
+import System.IO (hReady, stdin)
 
 main :: IO ()
 main =
   runRuntime $ do
-    state1 <-
-      loadVersion followingVersionId_1 Nothing
+    state1' <- state1''
 
-    updatePackageDatabase
-    state2 <-
-      loadVersion followingVersionId_2
-        =<< loadTransformer followingTransformerId_1_2 state1
+    _ <- liftIO getLine
+
+    state2 <- loadVersion followingVersionId_2 state1'
 
     updatePackageDatabase
     void $
       loadVersion followingVersionId_3
         =<< loadTransformer followingTransformerId_2_3 state2
+
+state1'' :: Runtime (Maybe a)
+state1'' = do
+  state1 <-
+    loadVersion followingVersionId_1 Nothing
+
+  updatePackageDatabase
+  liftIO . evaluate
+    =<< ( ( loadTransformer $!
+              followingTransformerId_1_2
+          )
+            $! state1
+        )

--- a/examples/following/demo/app/Main.hs
+++ b/examples/following/demo/app/Main.hs
@@ -13,19 +13,10 @@ import Lowarn.Runtime
 main :: IO ()
 main =
   runRuntime $ do
-    state1 <-
-      loadVersion followingVersionId_1 Nothing
+    state1 <- loadVersion followingVersionId_1 Nothing
 
     updatePackageDatabase
-    state2 <-
-      loadTransformerAndVersion
-        followingTransformerId_1_2
-        followingVersionId_2
-        state1
+    state2 <- loadTransformerAndVersion followingTransformerId_1_2 state1
 
     updatePackageDatabase
-    void $
-      loadTransformerAndVersion
-        followingTransformerId_2_3
-        followingVersionId_3
-        state2
+    void $ loadTransformerAndVersion followingTransformerId_2_3 state2

--- a/examples/following/demo/following.cabal
+++ b/examples/following/demo/following.cabal
@@ -40,7 +40,7 @@ executable following-exe
       Paths_following
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -rdynamic -fkeep-cafs -fwhole-archive-hs-libs
   build-depends:
       base >=4.7 && <5
     , following

--- a/examples/following/demo/following.cabal
+++ b/examples/following/demo/following.cabal
@@ -27,7 +27,7 @@ library
       Paths_following
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -prof
   build-depends:
       base >=4.7 && <5
     , lowarn
@@ -40,7 +40,7 @@ executable following-exe
       Paths_following
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -prof -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , following

--- a/examples/following/demo/following.cabal
+++ b/examples/following/demo/following.cabal
@@ -27,7 +27,7 @@ library
       Paths_following
   hs-source-dirs:
       src
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -prof
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
     , lowarn
@@ -40,7 +40,7 @@ executable following-exe
       Paths_following
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -prof -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       base >=4.7 && <5
     , following

--- a/examples/following/demo/package.yaml
+++ b/examples/following/demo/package.yaml
@@ -35,5 +35,8 @@ executables:
     - -threaded
     - -rtsopts
     - -with-rtsopts=-N
+    - -rdynamic
+    - -fkeep-cafs
+    - -fwhole-archive-hs-libs
     dependencies:
     - following

--- a/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/0-1.0.0/src/Transformer_following.hs
@@ -1,7 +1,4 @@
-module Transformer_following
-  ( transformer,
-  )
-where
+module Transformer_following () where
 
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer (Transformer))

--- a/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
@@ -4,21 +4,19 @@
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Transformer_following
-  ( transformer,
-  )
-where
+module Transformer_following () where
 
 import Control.Arrow (first)
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer)
-import Lowarn.Transformer (Transformable (transform, transformer))
-import System.Random (mkStdGen, randomR)
-import System.Random.Stateful (applyIOGen, newIOGenM)
 import qualified "lowarn-version-following-v1v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
 import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as NextVersion
+import Lowarn.Transformer (Transformable (transform))
+import Lowarn.Transformer.Strict (StrictTransformable (transformer'))
+import System.Random (mkStdGen, randomR)
+import System.Random.Stateful (applyIOGen, newIOGenM)
 
 instance Transformable [PreviousVersion.User] (Seq NextVersion.User) where
   transform :: [PreviousVersion.User] -> IO (Maybe (Seq NextVersion.User))
@@ -39,4 +37,4 @@ foreign export ccall "hs_transformer_v1v0v0_v2v0v0"
 
 hsTransformer ::
   IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
-hsTransformer = newStablePtr transformer
+hsTransformer = newStablePtr transformer'

--- a/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/1.0.0-2.0.0/src/Transformer_following.hs
@@ -11,12 +11,12 @@ import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer)
-import qualified "lowarn-version-following-v1v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
-import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as NextVersion
 import Lowarn.Transformer (Transformable (transform))
 import Lowarn.Transformer.Strict (StrictTransformable (transformer'))
 import System.Random (mkStdGen, randomR)
 import System.Random.Stateful (applyIOGen, newIOGenM)
+import qualified "lowarn-version-following-v1v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
+import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as NextVersion
 
 instance Transformable [PreviousVersion.User] (Seq NextVersion.User) where
   transform :: [PreviousVersion.User] -> IO (Maybe (Seq NextVersion.User))

--- a/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
@@ -4,18 +4,16 @@
 {-# LANGUAGE PackageImports #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Transformer_following
-  ( transformer,
-  )
-where
+module Transformer_following () where
 
 import Control.Arrow
 import Data.Foldable (toList)
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer)
-import Lowarn.Transformer (Transformable (transformer))
 import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
 import qualified "lowarn-version-following-v3v0v0" Lowarn.ExampleProgram.Following as NextVersion
+import Lowarn.Transformer (Transformable (transformer))
+import Lowarn.Transformer.Strict (StrictTransformable (transformer'))
 
 instance
   (Traversable t) =>
@@ -34,4 +32,4 @@ foreign export ccall "hs_transformer_v2v0v0_v3v0v0"
 
 hsTransformer ::
   IO (StablePtr (Transformer PreviousVersion.State NextVersion.State))
-hsTransformer = newStablePtr transformer
+hsTransformer = newStablePtr transformer'

--- a/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
+++ b/examples/following/transformers/2.0.0-3.0.0/src/Transformer_following.hs
@@ -10,10 +10,10 @@ import Control.Arrow
 import Data.Foldable (toList)
 import Foreign (StablePtr, newStablePtr)
 import Lowarn (Transformer)
-import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
-import qualified "lowarn-version-following-v3v0v0" Lowarn.ExampleProgram.Following as NextVersion
 import Lowarn.Transformer (Transformable (transformer))
 import Lowarn.Transformer.Strict (StrictTransformable (transformer'))
+import qualified "lowarn-version-following-v2v0v0" Lowarn.ExampleProgram.Following as PreviousVersion
+import qualified "lowarn-version-following-v3v0v0" Lowarn.ExampleProgram.Following as NextVersion
 
 instance
   (Traversable t) =>

--- a/examples/following/versions/2.0.0/lowarn-version-following-v2v0v0.cabal
+++ b/examples/following/versions/2.0.0/lowarn-version-following-v2v0v0.cabal
@@ -31,6 +31,7 @@ library
   build-depends:
       base >=4.7 && <5
     , containers
+    , deepseq >=1.4
     , lowarn
     , lowarn-plugin
     , lowarn-transformer

--- a/examples/following/versions/2.0.0/package.yaml
+++ b/examples/following/versions/2.0.0/package.yaml
@@ -11,6 +11,7 @@ description:         Lowarn demo program 2
 dependencies:
 - base >= 4.7 && < 5
 - containers
+- deepseq >= 1.4
 - lowarn
 - lowarn-plugin
 - lowarn-transformer

--- a/examples/following/versions/2.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/2.0.0/src/EntryPoint_following.hs
@@ -12,10 +12,12 @@ import System.IO
   ( stdin,
     stdout,
   )
+import System.Mem (performGC)
 
 entryPoint :: EntryPoint State
 entryPoint = EntryPoint $
-  \runtimeData ->
+  \runtimeData -> do
+    performGC
     eventLoop runtimeData $
       fromMaybe (State Seq.empty stdin stdout) (lastState runtimeData)
 

--- a/examples/following/versions/2.0.0/src/Lowarn/ExampleProgram/Following.hs
+++ b/examples/following/versions/2.0.0/src/Lowarn/ExampleProgram/Following.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Lowarn.ExampleProgram.Following
   ( User (..),
@@ -11,10 +9,12 @@ module Lowarn.ExampleProgram.Following
   )
 where
 
+import Control.DeepSeq
 import Data.Sequence (Seq)
 import qualified Data.Sequence as Seq
+import qualified GHC.Generics as GHC (Generic)
 import Lowarn (RuntimeData, isUpdateAvailable)
-import Lowarn.Transformer (deriveGeneric)
+import Lowarn.Transformer (Generic, HasDatatypeInfo)
 import System.IO
   ( Handle,
     hFlush,
@@ -28,15 +28,17 @@ data User = User
   { _nickname :: String,
     _userId :: Int
   }
+  deriving (GHC.Generic, NFData, Generic, HasDatatypeInfo)
 
 data State = State
   { _users :: Seq User,
     _in :: Handle,
     _out :: Handle
   }
+  deriving (GHC.Generic, Generic, HasDatatypeInfo)
 
-deriveGeneric ''User
-deriveGeneric ''State
+instance NFData State where
+  rnf state = state `seq` rnf (_users state)
 
 showUser :: User -> String
 showUser (User nickname userId) = printf "%s#%04d" nickname userId

--- a/examples/following/versions/3.0.0/lowarn-version-following-v3v0v0.cabal
+++ b/examples/following/versions/3.0.0/lowarn-version-following-v3v0v0.cabal
@@ -30,6 +30,7 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -fplugin Lowarn.Plugin
   build-depends:
       base >=4.7 && <5
+    , deepseq >=1.4
     , lowarn
     , lowarn-plugin
     , lowarn-transformer

--- a/examples/following/versions/3.0.0/package.yaml
+++ b/examples/following/versions/3.0.0/package.yaml
@@ -10,6 +10,7 @@ description:         Lowarn demo program 3
 
 dependencies:
 - base >= 4.7 && < 5
+- deepseq >= 1.4
 - lowarn
 - lowarn-plugin
 - lowarn-transformer

--- a/examples/following/versions/3.0.0/src/EntryPoint_following.hs
+++ b/examples/following/versions/3.0.0/src/EntryPoint_following.hs
@@ -11,10 +11,12 @@ import System.IO
   ( stdin,
     stdout,
   )
+import System.Mem (performGC)
 
 entryPoint :: EntryPoint State
 entryPoint = EntryPoint $
-  \runtimeData ->
+  \runtimeData -> do
+    performGC
     eventLoop runtimeData $
       fromMaybe (State [] stdin stdout) (lastState runtimeData)
 

--- a/examples/following/versions/3.0.0/src/Lowarn/ExampleProgram/Following.hs
+++ b/examples/following/versions/3.0.0/src/Lowarn/ExampleProgram/Following.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE TypeFamilies #-}
 
 module Lowarn.ExampleProgram.Following
   ( User (..),
@@ -11,8 +9,10 @@ module Lowarn.ExampleProgram.Following
   )
 where
 
+import Control.DeepSeq
+import qualified GHC.Generics as GHC (Generic)
 import Lowarn (RuntimeData, isUpdateAvailable)
-import Lowarn.Transformer (deriveGeneric)
+import Lowarn.Transformer (Generic, HasDatatypeInfo)
 import System.IO
   ( Handle,
     hFlush,
@@ -24,15 +24,17 @@ import Text.Regex.TDFA
 newtype User = User
   { _tag :: String
   }
+  deriving (GHC.Generic, NFData, Generic, HasDatatypeInfo)
 
 data State = State
   { _users :: [User],
     _in :: Handle,
     _out :: Handle
   }
+  deriving (GHC.Generic, Generic, HasDatatypeInfo)
 
-deriveGeneric ''User
-deriveGeneric ''State
+instance NFData State where
+  rnf state = state `seq` rnf (_users state)
 
 showUser :: User -> String
 showUser = _tag

--- a/examples/manual-following/demo/app/Main.hs
+++ b/examples/manual-following/demo/app/Main.hs
@@ -4,7 +4,7 @@ import Control.Monad (void)
 import Lowarn.ExampleProgram.ManualFollowing.TransformerId
 import Lowarn.ExampleProgram.ManualFollowing.VersionId
 import Lowarn.Runtime
-  ( loadTransformer,
+  ( loadTransformerAndVersion,
     loadVersion,
     runRuntime,
     updatePackageDatabase,
@@ -18,10 +18,14 @@ main =
 
     updatePackageDatabase
     state2 <-
-      loadVersion manualFollowingVersionId_2
-        =<< loadTransformer manualFollowingTransformerId_1_2 state1
+      loadTransformerAndVersion
+        manualFollowingTransformerId_1_2
+        manualFollowingVersionId_2
+        state1
 
     updatePackageDatabase
     void $
-      loadVersion manualFollowingVersionId_3
-        =<< loadTransformer manualFollowingTransformerId_2_3 state2
+      loadTransformerAndVersion
+        manualFollowingTransformerId_2_3
+        manualFollowingVersionId_3
+        state2

--- a/examples/manual-following/demo/app/Main.hs
+++ b/examples/manual-following/demo/app/Main.hs
@@ -13,19 +13,10 @@ import Lowarn.Runtime
 main :: IO ()
 main =
   runRuntime $ do
-    state1 <-
-      loadVersion manualFollowingVersionId_1 Nothing
+    state1 <- loadVersion manualFollowingVersionId_1 Nothing
 
     updatePackageDatabase
-    state2 <-
-      loadTransformerAndVersion
-        manualFollowingTransformerId_1_2
-        manualFollowingVersionId_2
-        state1
+    state2 <- loadTransformerAndVersion manualFollowingTransformerId_1_2 state1
 
     updatePackageDatabase
-    void $
-      loadTransformerAndVersion
-        manualFollowingTransformerId_2_3
-        manualFollowingVersionId_3
-        state2
+    void $ loadTransformerAndVersion manualFollowingTransformerId_2_3 state2

--- a/runtime/lowarn-runtime.cabal
+++ b/runtime/lowarn-runtime.cabal
@@ -36,9 +36,11 @@ library
       Glob >=0.10.2 && <0.11
     , base >=4.7 && <5
     , containers
+    , free
     , ghc ==9.2.5
     , ghc-boot ==9.2.5
     , ghc-paths
+    , ghci ==9.2.5
     , lowarn
     , transformers
     , unix

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -17,9 +17,11 @@ description:         Please see the README on GitHub at <https://github.com/jona
 dependencies:
 - base >= 4.7 && < 5
 - containers
+- free
 - ghc == 9.2.5
 - ghc-boot == 9.2.5
 - ghc-paths
+- ghci == 9.2.5
 - Glob >= 0.10.2 && < 0.11
 - lowarn
 - transformers

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -24,7 +24,6 @@ module Lowarn.Linker
     -- * Entity getting
     GetEntityProgram,
     getEntity,
-    Entity (..),
   )
 where
 
@@ -59,6 +58,7 @@ import GHCi.ObjLink
 import System.Environment (lookupEnv)
 import System.FilePath.Glob (CompOptions (..), compileWith, globDir1)
 import Text.Printf (printf)
+import Unsafe.Coerce (unsafeCoerce)
 
 foreign import ccall "dynamic"
   mkStablePtr :: FunPtr (IO (StablePtr a)) -> IO (StablePtr a)
@@ -109,10 +109,8 @@ data GetEntity a = GetEntity
 
 type GetEntityProgram = Free GetEntity
 
-data Entity = forall a. Entity a
-
-getEntity :: String -> GetEntityProgram (Maybe Entity)
-getEntity entityName = liftF (GetEntity entityName (fmap Entity))
+getEntity :: String -> GetEntityProgram (Maybe a)
+getEntity entityName = liftF (GetEntity entityName (fmap unsafeCoerce))
 
 -- | Action that gives an entity exported by a module in a package in the
 -- package database. The module is linked if it hasn't already been. @Nothing@

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -46,6 +46,7 @@ import GHC.Runtime.Interpreter
 import GHC.Unit hiding (moduleName)
 import System.Environment (lookupEnv)
 import System.FilePath.Glob (CompOptions (..), compileWith, globDir1)
+import System.Mem (performGC)
 import Text.Printf (printf)
 
 foreign import ccall "dynamic"
@@ -70,6 +71,7 @@ runLinker :: Linker a -> IO a
 runLinker linker =
   defaultErrorHandler defaultFatalMessager defaultFlushOut $
     runGhc (Just libdir) $ do
+      liftIO performGC
       flags <- getSessionDynFlags
       flags' <-
         liftIO $

--- a/runtime/src/Lowarn/Runtime.hs
+++ b/runtime/src/Lowarn/Runtime.hs
@@ -11,7 +11,6 @@ module Lowarn.Runtime
   ( Runtime,
     runRuntime,
     loadVersion,
-    loadTransformer,
     loadTransformerAndVersion,
     updatePackageDatabase,
     liftLinker,
@@ -141,28 +140,6 @@ loadVersion versionId mPreviousState = do
     moduleName =
       showEntryPointModuleName . VersionId._programName $ versionId
     packageName = showVersionPackageName versionId
-
--- | Action that loads and runs a given state transformer, producing the state
--- for the next version of a program.
-loadTransformer ::
-  -- | The ID corresponding to the transformer.
-  TransformerId ->
-  -- | State from the previous version of the program.
-  a ->
-  Runtime (Maybe b)
-loadTransformer transformerId previousState =
-  withLinkedEntity
-    packageName
-    moduleName
-    ( showTransformerExport
-        (_previousVersionNumber transformerId)
-        (_nextVersionNumber transformerId)
-    )
-    (`unTransformer` previousState)
-  where
-    moduleName =
-      showTransformerModuleName . TransformerId._programName $ transformerId
-    packageName = showTransformerPackageName transformerId
 
 -- | Action that loads and runs a given state transformer, producing the state
 -- for the next version of a program.

--- a/runtime/src/Lowarn/Runtime.hs
+++ b/runtime/src/Lowarn/Runtime.hs
@@ -44,7 +44,8 @@ import Lowarn.Linker
 import qualified Lowarn.Linker as Linker (updatePackageDatabase)
 import Lowarn.ProgramName (showEntryPointModuleName, showTransformerModuleName)
 import Lowarn.TransformerId
-  ( TransformerId (_nextVersionNumber, _previousVersionNumber),
+  ( TransformerId (..),
+    nextVersionId,
     showTransformerPackageName,
   )
 import qualified Lowarn.TransformerId as TransformerId (_programName)
@@ -146,12 +147,10 @@ loadVersion versionId mPreviousState = do
 loadTransformerAndVersion ::
   -- | The ID corresponding to the transformer.
   TransformerId ->
-  -- | The ID corresponding to the version.
-  VersionId ->
   -- | State from the previous version of the program.
   a ->
   Runtime b
-loadTransformerAndVersion transformerId versionId previousState = do
+loadTransformerAndVersion transformerId previousState = do
   updateSignalRegister <- Runtime ask
   withLinkedEntity'
     packageName
@@ -160,7 +159,7 @@ loadTransformerAndVersion transformerId versionId previousState = do
         (_previousVersionNumber transformerId)
         (_nextVersionNumber transformerId)
     )
-    (showEntryPointExport $ _versionNumber versionId)
+    (showEntryPointExport $ _versionNumber $ nextVersionId transformerId)
     ( \(transformer, entryPoint) -> do
         previousState' <-
           evaluate =<< unTransformer transformer previousState

--- a/test/test/Spec/ManualDsu.hs
+++ b/test/test/Spec/ManualDsu.hs
@@ -4,12 +4,9 @@ module Spec.ManualDsu (manualDsuTests) where
 
 import Control.Monad (void)
 import Lowarn.ExampleProgram.Following.TransformerId
-import Lowarn.ExampleProgram.Following.VersionId
 import Lowarn.ExampleProgram.ManualFollowing.TransformerId
-import Lowarn.ExampleProgram.ManualFollowing.VersionId
 import Lowarn.Runtime (Runtime, loadTransformerAndVersion)
 import Lowarn.TransformerId (TransformerId)
-import Lowarn.VersionId (VersionId)
 import System.IO (Handle)
 import Test.Lowarn.Story
   ( Story,
@@ -24,45 +21,33 @@ import Test.Tasty (TestTree, testGroup)
 
 getExampleRuntime ::
   TransformerId ->
-  VersionId ->
   TransformerId ->
-  VersionId ->
   TransformerId ->
-  VersionId ->
   (Handle, Handle) ->
   Runtime ()
 getExampleRuntime
   transformerId_0_1
-  versionId_1
   transformerId_1_2
-  versionId_2
   transformerId_2_3
-  versionId_3
   handles =
     void $
-      loadTransformerAndVersion transformerId_0_1 versionId_1 handles
-        >>= loadTransformerAndVersion transformerId_1_2 versionId_2
-        >>= loadTransformerAndVersion transformerId_2_3 versionId_3
+      loadTransformerAndVersion transformerId_0_1 handles
+        >>= loadTransformerAndVersion transformerId_1_2
+        >>= loadTransformerAndVersion transformerId_2_3
 
 getExampleManualFollowingRuntime :: (Handle, Handle) -> Runtime ()
 getExampleManualFollowingRuntime =
   getExampleRuntime
     manualFollowingTransformerId_0_1
-    manualFollowingVersionId_1
     manualFollowingTransformerId_1_2
-    manualFollowingVersionId_2
     manualFollowingTransformerId_2_3
-    manualFollowingVersionId_3
 
 getExampleFollowingRuntime :: (Handle, Handle) -> Runtime ()
 getExampleFollowingRuntime =
   getExampleRuntime
     followingTransformerId_0_1
-    followingVersionId_1
     followingTransformerId_1_2
-    followingVersionId_2
     followingTransformerId_2_3
-    followingVersionId_3
 
 getExampleRuntimes :: [(String, (Handle, Handle) -> Runtime ())]
 getExampleRuntimes =

--- a/test/test/Spec/ManualDsu.hs
+++ b/test/test/Spec/ManualDsu.hs
@@ -7,7 +7,7 @@ import Lowarn.ExampleProgram.Following.TransformerId
 import Lowarn.ExampleProgram.Following.VersionId
 import Lowarn.ExampleProgram.ManualFollowing.TransformerId
 import Lowarn.ExampleProgram.ManualFollowing.VersionId
-import Lowarn.Runtime (Runtime, loadTransformer, loadVersion)
+import Lowarn.Runtime (Runtime, loadTransformerAndVersion)
 import Lowarn.TransformerId (TransformerId)
 import Lowarn.VersionId (VersionId)
 import System.IO (Handle)
@@ -40,12 +40,9 @@ getExampleRuntime
   versionId_3
   handles =
     void $
-      loadTransformer transformerId_0_1 handles
-        >>= loadVersion versionId_1
-        >>= loadTransformer transformerId_1_2
-        >>= loadVersion versionId_2
-        >>= loadTransformer transformerId_2_3
-        >>= loadVersion versionId_3
+      loadTransformerAndVersion transformerId_0_1 versionId_1 handles
+        >>= loadTransformerAndVersion transformerId_1_2 versionId_2
+        >>= loadTransformerAndVersion transformerId_2_3 versionId_3
 
 getExampleManualFollowingRuntime :: (Handle, Handle) -> Runtime ()
 getExampleManualFollowingRuntime =

--- a/test/test/Spec/Story.hs
+++ b/test/test/Spec/Story.hs
@@ -9,7 +9,7 @@ import Lowarn.ExampleProgram.ManualFollowing.TransformerId
 import Lowarn.ExampleProgram.ManualFollowing.VersionId
   ( manualFollowingVersionId_1,
   )
-import Lowarn.Runtime (Runtime, loadTransformer, loadVersion)
+import Lowarn.Runtime (Runtime, loadTransformerAndVersion)
 import System.IO (Handle)
 import Test.Lowarn.Story
   ( inputLine,
@@ -23,8 +23,10 @@ import Test.Tasty (TestTree, testGroup)
 getExampleRuntime :: (Handle, Handle) -> Runtime ()
 getExampleRuntime handles =
   void $
-    loadTransformer manualFollowingTransformerId_0_1 handles
-      >>= loadVersion manualFollowingVersionId_1
+    loadTransformerAndVersion
+      manualFollowingTransformerId_0_1
+      manualFollowingVersionId_1
+      handles
 
 timeout :: Int
 timeout = 40000000

--- a/test/test/Spec/Story.hs
+++ b/test/test/Spec/Story.hs
@@ -6,9 +6,6 @@ import Control.Monad (void)
 import Lowarn.ExampleProgram.ManualFollowing.TransformerId
   ( manualFollowingTransformerId_0_1,
   )
-import Lowarn.ExampleProgram.ManualFollowing.VersionId
-  ( manualFollowingVersionId_1,
-  )
 import Lowarn.Runtime (Runtime, loadTransformerAndVersion)
 import System.IO (Handle)
 import Test.Lowarn.Story
@@ -22,11 +19,7 @@ import Test.Tasty (TestTree, testGroup)
 
 getExampleRuntime :: (Handle, Handle) -> Runtime ()
 getExampleRuntime handles =
-  void $
-    loadTransformerAndVersion
-      manualFollowingTransformerId_0_1
-      manualFollowingVersionId_1
-      handles
+  void $ loadTransformerAndVersion manualFollowingTransformerId_0_1 handles
 
 timeout :: Int
 timeout = 40000000

--- a/transformer/lowarn-transformer.cabal
+++ b/transformer/lowarn-transformer.cabal
@@ -26,6 +26,7 @@ source-repository head
 library
   exposed-modules:
       Lowarn.Transformer
+      Lowarn.Transformer.Strict
   other-modules:
       Paths_lowarn_transformer
   hs-source-dirs:
@@ -33,6 +34,7 @@ library
   ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints
   build-depends:
       base >=4.7 && <5
+    , deepseq >=1.4
     , generics-sop >=0.5.1 && <0.6
     , lowarn
   default-language: Haskell2010

--- a/transformer/package.yaml
+++ b/transformer/package.yaml
@@ -16,6 +16,7 @@ description:         Please see the README on GitHub at <https://github.com/jona
 
 dependencies:
 - base >= 4.7 && < 5
+- deepseq >= 1.4
 - generics-sop >= 0.5.1 && < 0.6
 - lowarn
 

--- a/transformer/src/Lowarn/Transformer.hs
+++ b/transformer/src/Lowarn/Transformer.hs
@@ -52,6 +52,7 @@ module Lowarn.Transformer
 
     -- * Re-exports from generic-sop
     Generic,
+    HasDatatypeInfo,
     deriveGeneric,
   )
 where

--- a/transformer/src/Lowarn/Transformer/Strict.hs
+++ b/transformer/src/Lowarn/Transformer/Strict.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE MonoLocalBinds #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Lowarn.Transformer.Strict
+  ( StrictTransformable (..),
+    forceTransformer,
+  )
+where
+
+import Control.Arrow
+import Control.DeepSeq
+import Control.Exception (evaluate)
+import Lowarn (Transformer (..))
+import Lowarn.Transformer (Transformable (..))
+
+class NFData b => StrictTransformable a b where
+  {-# MINIMAL transformer' | transform' #-}
+
+  -- | Gives a transformer that attempts to transform data from type @a@ to type
+  -- @b@.
+  transformer' :: Transformer a b
+  transformer' = Transformer transform'
+
+  -- | Attempt to transform data from type @a@ to type @b@, giving @Nothing@ if
+  -- this is not possible.
+  transform' :: a -> IO (Maybe b)
+  transform' = unTransformer transformer'
+
+instance (Transformable a b, NFData b) => StrictTransformable a b where
+  transformer' :: Transformer a b
+  transformer' = forceTransformer <<< transformer
+
+forceTransformer :: (NFData a) => Transformer a a
+forceTransformer = Transformer $ fmap Just . evaluate . force


### PR DESCRIPTION
Add `Lowarn.Transformer.Strict` module, use it in the automatic demo, and refactor the linker and runtime to not retain CAFs. As a result of this, `loadTransformer` has been replaced with `loadTransformerAndVersion`.