### PR TITLE
Stop retaining CAFs for code unloading

### DIFF
--- a/examples/following/demo/following.cabal
+++ b/examples/following/demo/following.cabal
@@ -40,7 +40,7 @@ executable following-exe
       Paths_following
   hs-source-dirs:
       app
-  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -threaded -rtsopts -with-rtsopts=-N -rdynamic -fkeep-cafs -fwhole-archive-hs-libs
+  ghc-options: -Wall -Wcompat -Widentities -Wincomplete-record-updates -Wincomplete-uni-patterns -Wmissing-export-lists -Wmissing-home-modules -Wpartial-fields -Wredundant-constraints -rtsopts -rdynamic -fkeep-cafs -fwhole-archive-hs-libs
   build-depends:
       base >=4.7 && <5
     , following

--- a/examples/following/demo/package.yaml
+++ b/examples/following/demo/package.yaml
@@ -32,9 +32,9 @@ executables:
     main:                Main.hs
     source-dirs:         app
     ghc-options:
-    - -threaded
+    # - -threaded
     - -rtsopts
-    - -with-rtsopts=-N
+    # - -with-rtsopts=-N
     - -rdynamic
     - -fkeep-cafs
     - -fwhole-archive-hs-libs

--- a/runtime/src/Lowarn/Linker.hs
+++ b/runtime/src/Lowarn/Linker.hs
@@ -105,8 +105,7 @@ runLinker linker shouldUnload =
       setSessionDynFlags flags' {ghcLink = LinkStaticLib}
       liftIO $
         initObjLinker $
-          -- TODO: Replace RetainCAFs with DontRetainCAFs when unloading.
-          if shouldUnload then RetainCAFs else RetainCAFs
+          if shouldUnload then DontRetainCAFs else RetainCAFs
       runReaderT
         ( evalStateT (unLinker linker) $ CurrentLinkables Set.empty
         )


### PR DESCRIPTION
Stops retaining CAFs when unloading code is enabled, which lets code unloading actually happens. This currently requires that the program is single-threaded.