### PR TITLE
Add shared library support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -7,3 +7,42 @@ packages:
   , examples/*/updates/*/*.cabal
 
 flags: +cabal
+
+package *
+  ghc-options: -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
+
+package lowarn-version-following-v1v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-version-following-v2v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-version-following-v3v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-update-following-v0v0v0-v1v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-update-following-v1v0v0-v2v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-update-following-v2v0v0-v3v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-version-manual-following-v1v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-version-manual-following-v2v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-version-manual-following-v3v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-update-manual-following-v0v0v0-v1v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-update-manual-following-v1v0v0-v2v0v0
+  ghc-options: -fno-keep-cafs
+
+package lowarn-update-manual-following-v2v0v0-v3v0v0
+  ghc-options: -fno-keep-cafs

--- a/cabal.project
+++ b/cabal.project
@@ -8,41 +8,41 @@ packages:
 
 flags: +cabal
 
-package *
-  ghc-options: -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
-
-package lowarn-version-following-v1v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-version-following-v2v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-version-following-v3v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-update-following-v0v0v0-v1v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-update-following-v1v0v0-v2v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-update-following-v2v0v0-v3v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-version-manual-following-v1v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-version-manual-following-v2v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-version-manual-following-v3v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-update-manual-following-v0v0v0-v1v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-update-manual-following-v1v0v0-v2v0v0
-  ghc-options: -fno-keep-cafs
-
-package lowarn-update-manual-following-v2v0v0-v3v0v0
-  ghc-options: -fno-keep-cafs
+-- package *
+--   ghc-options: -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
+--
+-- package lowarn-version-following-v1v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-version-following-v2v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-version-following-v3v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-update-following-v0v0v0-v1v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-update-following-v1v0v0-v2v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-update-following-v2v0v0-v3v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-version-manual-following-v1v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-version-manual-following-v2v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-version-manual-following-v3v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-update-manual-following-v0v0v0-v1v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-update-manual-following-v1v0v0-v2v0v0
+--   ghc-options: -fno-keep-cafs
+--
+-- package lowarn-update-manual-following-v2v0v0-v3v0v0
+--   ghc-options: -fno-keep-cafs

--- a/cli/src/Lowarn/Cli/Run.hs
+++ b/cli/src/Lowarn/Cli/Run.hs
@@ -31,7 +31,7 @@ run lowarnEnv@LowarnEnv {lowarnEnvConfig = LowarnConfig {..}} mVersionNumber =
   runRuntime
     (runWithState lowarnEnv $ Left mVersionNumber)
     lowarnConfigLazyUpdates
-    True
+    False
     >>= \case
       Left e ->
         hPutStrLn stderr $ printf "An error occurred in Lowarn's runtime:\n%s" e

--- a/cli/src/Lowarn/Cli/Run.hs
+++ b/cli/src/Lowarn/Cli/Run.hs
@@ -31,6 +31,7 @@ run lowarnEnv@LowarnEnv {lowarnEnvConfig = LowarnConfig {..}} mVersionNumber =
   runRuntime
     (runWithState lowarnEnv $ Left mVersionNumber)
     lowarnConfigLazyUpdates
+    True
     >>= \case
       Left e ->
         hPutStrLn stderr $ printf "An error occurred in Lowarn's runtime:\n%s" e

--- a/examples/following/demo/app/Main.hs
+++ b/examples/following/demo/app/Main.hs
@@ -7,7 +7,7 @@ import Lowarn.Runtime
 
 main :: IO ()
 main =
-  runRuntime runtime True True
+  runRuntime runtime True False
   where
     runtime = do
       state1 <- loadVersion followingVersionId_1 Nothing

--- a/examples/following/demo/app/Main.hs
+++ b/examples/following/demo/app/Main.hs
@@ -7,7 +7,7 @@ import Lowarn.Runtime
 
 main :: IO ()
 main =
-  runRuntime runtime True
+  runRuntime runtime True True
   where
     runtime = do
       state1 <- loadVersion followingVersionId_1 Nothing

--- a/examples/manual-following/demo/app/Main.hs
+++ b/examples/manual-following/demo/app/Main.hs
@@ -7,7 +7,7 @@ import Lowarn.Runtime
 
 main :: IO ()
 main =
-  runRuntime runtime False
+  runRuntime runtime False False
   where
     runtime = do
       state1 <- loadVersion manualFollowingVersionId_1 Nothing

--- a/runtime/src/Lowarn/Runtime.hs
+++ b/runtime/src/Lowarn/Runtime.hs
@@ -46,8 +46,10 @@ runRuntime ::
   -- | Whether or not to unload code (may result in segmentation faults for lazy
   -- state transformations).
   Bool ->
+  -- | Whether or not to use the system linker (rather than the GHC linker).
+  Bool ->
   IO a
-runRuntime runtime shouldUnload = do
+runRuntime runtime shouldUnload isDynamic = do
   updateSignalRegister <- mkUpdateSignalRegister
   previousSignalHandler <-
     installHandler
@@ -55,7 +57,10 @@ runRuntime runtime shouldUnload = do
       (Catch (void $ fillUpdateSignalRegister updateSignalRegister))
       Nothing
   output <-
-    runLinker (runReaderT (unRuntime runtime) updateSignalRegister) shouldUnload
+    runLinker
+      (runReaderT (unRuntime runtime) updateSignalRegister)
+      shouldUnload
+      isDynamic
   liftIO $ void $ installHandler sigUSR2 previousSignalHandler Nothing
   return output
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -29,3 +29,18 @@ packages:
 - test
 - test-types
 - transformer
+
+ghc-options:
+  "$everything": -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
+  lowarn-version-following-v1v0v0: -fno-keep-cafs
+  lowarn-version-following-v2v0v0: -fno-keep-cafs
+  lowarn-version-following-v3v0v0: -fno-keep-cafs
+  lowarn-update-following-v0v0v0-v1v0v0: -fno-keep-cafs
+  lowarn-update-following-v1v0v0-v2v0v0: -fno-keep-cafs
+  lowarn-update-following-v2v0v0-v3v0v0: -fno-keep-cafs
+  lowarn-version-manual-following-v1v0v0: -fno-keep-cafs
+  lowarn-version-manual-following-v2v0v0: -fno-keep-cafs
+  lowarn-version-manual-following-v3v0v0: -fno-keep-cafs
+  lowarn-update-manual-following-v0v0v0-v1v0v0: -fno-keep-cafs
+  lowarn-update-manual-following-v1v0v0-v2v0v0: -fno-keep-cafs
+  lowarn-update-manual-following-v2v0v0-v3v0v0: -fno-keep-cafs

--- a/stack.yaml
+++ b/stack.yaml
@@ -30,17 +30,17 @@ packages:
 - test-types
 - transformer
 
-ghc-options:
-  "$everything": -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
-  lowarn-version-following-v1v0v0: -fno-keep-cafs
-  lowarn-version-following-v2v0v0: -fno-keep-cafs
-  lowarn-version-following-v3v0v0: -fno-keep-cafs
-  lowarn-update-following-v0v0v0-v1v0v0: -fno-keep-cafs
-  lowarn-update-following-v1v0v0-v2v0v0: -fno-keep-cafs
-  lowarn-update-following-v2v0v0-v3v0v0: -fno-keep-cafs
-  lowarn-version-manual-following-v1v0v0: -fno-keep-cafs
-  lowarn-version-manual-following-v2v0v0: -fno-keep-cafs
-  lowarn-version-manual-following-v3v0v0: -fno-keep-cafs
-  lowarn-update-manual-following-v0v0v0-v1v0v0: -fno-keep-cafs
-  lowarn-update-manual-following-v1v0v0-v2v0v0: -fno-keep-cafs
-  lowarn-update-manual-following-v2v0v0-v3v0v0: -fno-keep-cafs
+# ghc-options:
+#   "$everything": -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
+#   lowarn-version-following-v1v0v0: -fno-keep-cafs
+#   lowarn-version-following-v2v0v0: -fno-keep-cafs
+#   lowarn-version-following-v3v0v0: -fno-keep-cafs
+#   lowarn-update-following-v0v0v0-v1v0v0: -fno-keep-cafs
+#   lowarn-update-following-v1v0v0-v2v0v0: -fno-keep-cafs
+#   lowarn-update-following-v2v0v0-v3v0v0: -fno-keep-cafs
+#   lowarn-version-manual-following-v1v0v0: -fno-keep-cafs
+#   lowarn-version-manual-following-v2v0v0: -fno-keep-cafs
+#   lowarn-version-manual-following-v3v0v0: -fno-keep-cafs
+#   lowarn-update-manual-following-v0v0v0-v1v0v0: -fno-keep-cafs
+#   lowarn-update-manual-following-v1v0v0-v2v0v0: -fno-keep-cafs
+#   lowarn-update-manual-following-v2v0v0-v3v0v0: -fno-keep-cafs

--- a/test/src/Test/Lowarn/Story.hs
+++ b/test/src/Test/Lowarn/Story.hs
@@ -112,6 +112,7 @@ runStory story getRuntime outputPath timeoutLength = do
                 ( getRuntime (inputReadHandle, outputWriteHandle)
                 )
                 False
+                False
           )
           ( \exception -> do
               shouldWriteExceptions <- readIORef shouldWriteExceptionsRef


### PR DESCRIPTION
Adds an option to the runtime and linker monads that loads shared libraries rather than object and archive files. This fixes one bug with unloading, but introduces another bug, as shared libraries cannot be unloaded. This pull request also includes commented-out flags that support this new feature.