### PR TITLE
Add coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,7 @@ dist-*
 *.hi
 
 .vscode
+
+coverage*.dat
+*.coverables
+coverage/

--- a/aeson/lowarn-aeson.cabal
+++ b/aeson/lowarn-aeson.cabal
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: https://github.com/jonathanjameswatson/lowarn
 
+flag dekking
+  description: Dekking is used to find coverage when this flag is true.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Lowarn.ProgramName.Aeson
@@ -40,3 +45,8 @@ library
     , lowarn
     , text >=1.2.5 && <1.3
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value

--- a/aeson/package.yaml
+++ b/aeson/package.yaml
@@ -20,6 +20,20 @@ dependencies:
 - lowarn
 - text >= 1.2.5 && < 1.3
 
+flags:
+  dekking:
+    description: "Dekking is used to find coverage when this flag is true."
+    default: False
+    manual: True
+
+when:
+  - condition: flag(dekking)
+    dependencies:
+    - dekking-plugin
+    - dekking-value
+    ghc-options:
+    - -fplugin=Dekking.Plugin
+
 ghc-options:
 - -Wall
 - -Wcompat

--- a/cabal.project
+++ b/cabal.project
@@ -8,6 +8,18 @@ packages:
 
 flags: +cabal
 
+source-repository-package
+  type: git
+  location: https://github.com/jonathanjameswatson/dekking.git
+  tag: ab90da723761df0e5aa848ce5dd3d810b9b1f214
+  subdir: dekking-plugin
+
+source-repository-package
+  type: git
+  location: https://github.com/jonathanjameswatson/dekking.git
+  tag: ab90da723761df0e5aa848ce5dd3d810b9b1f214
+  subdir: dekking-value
+
 -- package *
 --   ghc-options: -rdynamic -fwhole-archive-hs-libs -fkeep-cafs -dynamic
 --

--- a/cli/app/Main.hs
+++ b/cli/app/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE RecordWildCards #-}
 
@@ -36,14 +35,15 @@ versionNumberReader = do
         printf "The given version number \"%s\" is invalid." versionNumberString
 
 runParser :: Parser Command
-runParser = do
-  runOptionsVersion <-
-    optional $
-      option versionNumberReader $
-        long "version"
-          <> metavar "VERSION-NUMBER"
-          <> help "Override the starting version to run."
-  return $ RunCommand $ RunOptions {..}
+runParser =
+  RunCommand . RunOptions <$> runOptionsVersion
+  where
+    runOptionsVersion =
+      optional $
+        option versionNumberReader $
+          long "version"
+            <> metavar "VERSION-NUMBER"
+            <> help "Override the starting version to run."
 
 runParserInfo :: ParserInfo Command
 runParserInfo =
@@ -51,16 +51,16 @@ runParserInfo =
     fullDesc <> progDesc "Run programs that support DSU with Lowarn"
 
 parser :: Parser Options
-parser = do
-  optionsConfigFilePath <-
-    optional $
-      strOption $
-        long "lowarn-yaml"
-          <> metavar "LOWARN-YAML"
-          <> help "Override Lowarn CLI configuration file."
-  optionsCommand <-
-    hsubparser $ command "run" runParserInfo
-  return Options {..}
+parser =
+  Options <$> optionsCommand <*> optionsConfigFilePath
+  where
+    optionsConfigFilePath =
+      optional $
+        strOption $
+          long "lowarn-yaml"
+            <> metavar "LOWARN-YAML"
+            <> help "Override Lowarn CLI configuration file."
+    optionsCommand = hsubparser $ command "run" runParserInfo
 
 parserInfo :: ParserInfo Options
 parserInfo =

--- a/cli/lowarn-cli.cabal
+++ b/cli/lowarn-cli.cabal
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: https://github.com/jonathanjameswatson/lowarn
 
+flag dekking
+  description: Dekking is used to find coverage when this flag is true.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Lowarn.Cli.Config
@@ -45,6 +50,11 @@ library
     , transformers
     , yaml >=0.11.8 && <0.12
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value
 
 executable lowarn-cli
   main-is: Main.hs
@@ -66,3 +76,8 @@ executable lowarn-cli
     , transformers
     , yaml >=0.11.8 && <0.12
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value

--- a/cli/package.yaml
+++ b/cli/package.yaml
@@ -36,6 +36,20 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 
+flags:
+  dekking:
+    description: "Dekking is used to find coverage when this flag is true."
+    default: False
+    manual: True
+
+when:
+  - condition: flag(dekking)
+    dependencies:
+    - dekking-plugin
+    - dekking-value
+    ghc-options:
+    - -fplugin=Dekking.Plugin
+
 library:
   source-dirs: src
 

--- a/core/lowarn.cabal
+++ b/core/lowarn.cabal
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: https://github.com/jonathanjameswatson/lowarn
 
+flag dekking
+  description: Dekking is used to find coverage when this flag is true.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Lowarn
@@ -41,3 +46,8 @@ library
       base >=4.7 && <5
     , template-haskell >=2.18
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value

--- a/core/package.yaml
+++ b/core/package.yaml
@@ -29,5 +29,19 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 
+flags:
+  dekking:
+    description: "Dekking is used to find coverage when this flag is true."
+    default: False
+    manual: True
+
+when:
+  - condition: flag(dekking)
+    dependencies:
+    - dekking-plugin
+    - dekking-value
+    ghc-options:
+    - -fplugin=Dekking.Plugin
+
 library:
   source-dirs: src

--- a/coverage.sh
+++ b/coverage.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+SCRIPT=$(readlink -f "$0")
+
+cd "$(dirname "$SCRIPT")"
+find . -type f -name "*.coverables" -exec rm {} \;
+find . -type f -name "coverage*.dat" -exec rm {} \;
+cabal build all -f dekking
+LOWARN_PACKAGE_ENV=$(realpath .ghc.environment*) cabal test all -f dekking
+cabal-docspec
+find . -type f -name "coverage*.dat" | sed -e 's/^/--coverage=/' | xargs dekking-report --coverables . --output coverage

--- a/inject/app/Main.hs
+++ b/inject/app/Main.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE ApplicativeDo #-}
 {-# LANGUAGE RecordWildCards #-}
 
 module Main (main) where
@@ -30,13 +29,18 @@ fileVar = argument str . (metavar "FILE" <>) . help
 
 parser :: Parser Arguments
 parser = do
-  argumentsOriginalPath <- fileVar "Path to the original file."
-  argumentsInputPath <- fileVar "Path to the input file."
-  argumentsOutputPath <- fileVar "Path to the output file."
-  argumentsProgramName <-
-    argument programNameReader $
-      metavar "PROGRAMNAME" <> help "Name of the program."
-  return Arguments {..}
+  Arguments
+    <$> argumentsOriginalPath
+    <*> argumentsInputPath
+    <*> argumentsOutputPath
+    <*> argumentsProgramName
+  where
+    argumentsOriginalPath = fileVar "Path to the original file."
+    argumentsInputPath = fileVar "Path to the input file."
+    argumentsOutputPath = fileVar "Path to the output file."
+    argumentsProgramName =
+      argument programNameReader $
+        metavar "PROGRAMNAME" <> help "Name of the program."
 
 parserInfo :: ParserInfo Arguments
 parserInfo =

--- a/inject/lowarn-inject.cabal
+++ b/inject/lowarn-inject.cabal
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: https://github.com/jonathanjameswatson/lowarn
 
+flag dekking
+  description: Dekking is used to find coverage when this flag is true.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Lowarn.Inject
@@ -41,6 +46,11 @@ library
     , ghc-tcplugin-api ==0.9.0.0
     , lowarn
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value
 
 executable lowarn-inject
   main-is: Main.hs
@@ -57,3 +67,8 @@ executable lowarn-inject
     , lowarn-inject
     , optparse-applicative ==0.17.*
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value

--- a/inject/package.yaml
+++ b/inject/package.yaml
@@ -31,6 +31,20 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 
+flags:
+  dekking:
+    description: "Dekking is used to find coverage when this flag is true."
+    default: False
+    manual: True
+
+when:
+  - condition: flag(dekking)
+    dependencies:
+    - dekking-plugin
+    - dekking-value
+    ghc-options:
+    - -fplugin=Dekking.Plugin
+
 library:
   source-dirs: src
 

--- a/runtime/lowarn-runtime.cabal
+++ b/runtime/lowarn-runtime.cabal
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: https://github.com/jonathanjameswatson/lowarn
 
+flag dekking
+  description: Dekking is used to find coverage when this flag is true.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Lowarn.Linker
@@ -45,3 +50,8 @@ library
     , transformers
     , unix
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value

--- a/runtime/package.yaml
+++ b/runtime/package.yaml
@@ -27,6 +27,20 @@ dependencies:
 - transformers
 - unix
 
+flags:
+  dekking:
+    description: "Dekking is used to find coverage when this flag is true."
+    default: False
+    manual: True
+
+when:
+  - condition: flag(dekking)
+    dependencies:
+    - dekking-plugin
+    - dekking-value
+    ghc-options:
+    - -fplugin=Dekking.Plugin
+
 ghc-options:
 - -Wall
 - -Wcompat

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,6 +4,11 @@ extra-deps:
 - combinat-0.2.10.0@sha256:adc1dbb532b048e419374e9e89dc4f92c47758300ffe8534a54849266706e53b,5318
 - compact-word-vectors-0.2.0.2@sha256:49cf00f224000f149306e7043c228fa33e3dba87f10589e8326388c3278ba594,2709
 - ghc-tcplugin-api-0.9.0.0
+- github: jonathanjameswatson/dekking
+  commit: ab90da723761df0e5aa848ce5dd3d810b9b1f214
+  subdirs:
+  - dekking-plugin
+  - dekking-value
 
 packages:
 - aeson

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -25,6 +25,32 @@ packages:
       size: 498
   original:
     hackage: ghc-tcplugin-api-0.9.0.0
+- completed:
+    name: dekking-plugin
+    pantry-tree:
+      sha256: e9f6327a6c9ef123495cc0f4b0d5ee012ac41ccd2b92d070202b15bf00fced06
+      size: 414
+    sha256: 07405713f675528b6c7db07f52bbb4400e6d83db2a4607db7ce30df7f394bc51
+    size: 31105
+    subdir: dekking-plugin
+    url: https://github.com/jonathanjameswatson/dekking/archive/3fe8904f860e881fc3589d24657b20dd9a53a662.tar.gz
+    version: 0.0.0.0
+  original:
+    subdir: dekking-plugin
+    url: https://github.com/jonathanjameswatson/dekking/archive/3fe8904f860e881fc3589d24657b20dd9a53a662.tar.gz
+- completed:
+    name: dekking-value
+    pantry-tree:
+      sha256: c8b865cb680bc319a12287561e337284edf7b02245354fd8a8fb45e287aa8a84
+      size: 288
+    sha256: 07405713f675528b6c7db07f52bbb4400e6d83db2a4607db7ce30df7f394bc51
+    size: 31105
+    subdir: dekking-value
+    url: https://github.com/jonathanjameswatson/dekking/archive/3fe8904f860e881fc3589d24657b20dd9a53a662.tar.gz
+    version: 0.0.0.0
+  original:
+    subdir: dekking-value
+    url: https://github.com/jonathanjameswatson/dekking/archive/3fe8904f860e881fc3589d24657b20dd9a53a662.tar.gz
 snapshots:
 - completed:
     sha256: b37c0abab16c7de352c45b85f8ecc8530b084209a2c42987a96c92b4a5e3cd65

--- a/transformer/lowarn-transformer.cabal
+++ b/transformer/lowarn-transformer.cabal
@@ -23,6 +23,11 @@ source-repository head
   type: git
   location: https://github.com/jonathanjameswatson/lowarn
 
+flag dekking
+  description: Dekking is used to find coverage when this flag is true.
+  manual: True
+  default: False
+
 library
   exposed-modules:
       Lowarn.Transformer
@@ -38,3 +43,8 @@ library
     , generics-sop >=0.5.1 && <0.6
     , lowarn
   default-language: Haskell2010
+  if flag(dekking)
+    ghc-options: -fplugin=Dekking.Plugin
+    build-depends:
+        dekking-plugin
+      , dekking-value

--- a/transformer/package.yaml
+++ b/transformer/package.yaml
@@ -31,5 +31,19 @@ ghc-options:
 - -Wpartial-fields
 - -Wredundant-constraints
 
+flags:
+  dekking:
+    description: "Dekking is used to find coverage when this flag is true."
+    default: False
+    manual: True
+
+when:
+  - condition: flag(dekking)
+    dependencies:
+    - dekking-plugin
+    - dekking-value
+    ghc-options:
+    - -fplugin=Dekking.Plugin
+
 library:
   source-dirs: src

--- a/transformer/src/Lowarn/Transformer.hs
+++ b/transformer/src/Lowarn/Transformer.hs
@@ -229,6 +229,7 @@ genericTransform ::
   IO (Maybe b)
 genericTransform = fmap (fmap to) . genericTransform' . from
 
+{-# ANN genericTransform' "NOCOVER" #-}
 genericTransform' ::
   (TransformableCodes' as bs) =>
   SOP I as ->


### PR DESCRIPTION
Uses a fork of Dekking to find coverage. This involves adding a `dekking` flag to certain packages, removing `ApplicativeDo` syntax, and adding an annotation to the transformers package.